### PR TITLE
move credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ after_success: |
     echo "Will build Documentation"
     
     # setup git
-    git config credential.helper 'store --file=.git/credentials'
     git config --global user.email "travis@travis-ci.com"
     git config --global user.name "Travis Bot"
     
@@ -46,6 +45,7 @@ after_success: |
     # now get into docs dirs
     cd build
     echo "https://${GHTOKEN}:@github.com" > .git/credentials
+    git config credential.helper 'store --file=.git/credentials'
     git add -A docs
     git add -A examples
     git add -A dist


### PR DESCRIPTION
Ok... now auth is used but refused, I think I stored the credentials in the wrong git directory, so it finds an empty token, and this should fix it I hope. 

Once again it works locally, but I'm not sure how to know wether the setup is right, or if it uses my local SSH key.

I've deployed manually in the meantime so http://phosphorjs.github.io/docs/ give you the docs. 



