### PR TITLE
IE fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "coveralls": "^2.11.9",
     "css-loader": "^0.23.1",
+    "es6-promise": "^3.2.1",
     "expect.js": "^0.3.1",
     "istanbul-instrumenter-loader": "^0.2.0",
     "karma": "^0.13.22",

--- a/test/karma-cov.conf.js
+++ b/test/karma-cov.conf.js
@@ -4,7 +4,10 @@ module.exports = function (config) {
     browsers: ['Firefox'],
     frameworks: ['mocha'],
     reporters: ['mocha', 'coverage'],
-    files: ['test/build/coverage.js'],
+    files: [
+      'node_modules/es6-promise/dist/es6-promise.js',
+      'test/build/coverage.js'
+    ],
     coverageReporter: {
       reporters : [
         { 'type': 'text' },

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -3,7 +3,10 @@ module.exports = function (config) {
     basePath: '..',
     frameworks: ['mocha'],
     reporters: ['mocha'],
-    files: ['test/build/bundle.js'],
+    files: [
+        'node_modules/es6-promise/dist/es6-promise.js',
+        'test/build/bundle.js'
+    ],
     port: 9876,
     colors: true,
     singleRun: true,

--- a/test/src/dom/query.spec.ts
+++ b/test/src/dom/query.spec.ts
@@ -113,7 +113,7 @@ describe('dom/query', () => {
       area.scrollTop = er.bottom - ar.bottom - threshold;
       top = area.scrollTop;
       scrollIfNeeded(area, elem, threshold);
-      expect(area.scrollTop).to.be(goal);
+      expect(Math.abs(area.scrollTop - goal) <= 1).to.be(true);
       document.body.removeChild(area);
     });
 

--- a/test/src/ui/keymap.spec.ts
+++ b/test/src/ui/keymap.spec.ts
@@ -265,7 +265,7 @@ describe('ui/keymap', () => {
       });
 
       it('should throw an error if binding has an invalid selector', () => {
-        let command = commands.addCommand('test', { execute: () => {  } });
+        let command = commands.addCommand('test', { execute: () => { } });
         let options = { keys: ['Ctrl ;'], selector: '..', command: 'test' };
         expect(() => { keymap.addBinding(options); }).to.throwError();
         command.dispose();


### PR DESCRIPTION
Without a new version of `simulate-event` and some attention paid to specific issues (that are posted separately) the full suite will not yet run in IE. But these two changes are necessary as well.