### PR TITLE
Allow Panel to take a node in the constructor.

### DIFF
--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -58,7 +58,7 @@ class Panel extends Widget {
    * @param options - The options for initializing the panel.
    */
   constructor(options: Panel.IOptions = {}) {
-    super();
+    super(options);
     this.addClass(PANEL_CLASS);
     this.layout = Private.createLayout(options);
   }
@@ -110,7 +110,7 @@ namespace Panel {
    * An options object for creating a panel.
    */
   export
-  interface IOptions {
+  interface IOptions extends Widget.IOptions {
     /**
      * The panel layout to use for the panel.
      *

--- a/test/src/ui/panel.spec.ts
+++ b/test/src/ui/panel.spec.ts
@@ -91,8 +91,10 @@ describe('ui/panel', () => {
       });
 
       it('should accept options', () => {
+        let node = document.createElement('div');
         let layout = new PanelLayout();
-        let panel = new Panel({ layout });
+        let panel = new Panel({ node, layout });
+        expect(panel.node).to.be(node);
         expect(panel.layout).to.be(layout);
       });
 


### PR DESCRIPTION
This was causing problems when we were using the Panel in ipywidgets, trying to set the node just like we set the node when creating a plain Widget.