### PR TITLE
Clean up path references in examples

### DIFF
--- a/src/algorithm/mutation.ts
+++ b/src/algorithm/mutation.ts
@@ -29,7 +29,7 @@ import {
  *
  * #### Example
  * ```typescript
- * import { move } from 'phosphor-core/lib/mutation';
+ * import { move } from 'phosphor/lib/algorithm/mutation';
  *
  * let data = [0, 1, 2, 3, 4];
  * move(data, 1, 2);  // [0, 2, 1, 3, 4]
@@ -72,7 +72,7 @@ function move<T>(object: MutableSequenceOrArrayLike<T>, fromIndex: number, toInd
  *
  * #### Example
  * ```typescript
- * import { reverse } from 'phosphor-core/lib/mutation';
+ * import { reverse } from 'phosphor/lib/algorithm/mutation';
  *
  * let data = [0, 1, 2, 3, 4];
  * reverse(data, 1, 3);  // [0, 3, 2, 1, 4]
@@ -122,7 +122,7 @@ function reverse<T>(object: MutableSequenceOrArrayLike<T>, first?: number, last?
  *
  * #### Example
  * ```typescript
- * import { rotate } from 'phosphor-core/lib/mutation';
+ * import { rotate } from 'phosphor/lib/algorithm/mutation';
  *
  * let data = [0, 1, 2, 3, 4];
  * rotate(data, 2);   // [2, 3, 4, 0, 1]

--- a/src/algorithm/searching.ts
+++ b/src/algorithm/searching.ts
@@ -29,7 +29,7 @@ import {
  *
  * #### Example
  * ```typescript
- * import { find } from 'phosphor-core/lib/searching';
+ * import { find } from 'phosphor/lib/algorithm/searching';
  *
  * interface IAnimal { species: string, name: string };
  *
@@ -81,7 +81,7 @@ function find<T>(object: IterableOrArrayLike<T>, fn: (value: T) => boolean): T {
  *
  * #### Example
  * ```typescript
- * import { indexOf } from 'phosphor-core/lib/searching';
+ * import { indexOf } from 'phosphor/lib/algorithm/searching';
  *
  * let data = ['one', 'two', 'three', 'four', 'one'];
  * indexOf(data, 'red');     // -1
@@ -134,7 +134,7 @@ function indexOf<T>(object: SequenceOrArrayLike<T>, value: T, fromIndex?: number
  *
  * #### Example
  * ```typescript
- * import { lastIndexOf } from 'phosphor-core/lib/searching';
+ * import { lastIndexOf } from 'phosphor/lib/algorithm/searching';
  *
  * let data = ['one', 'two', 'three', 'four', 'one'];
  * lastIndexOf(data, 'red');     // -1
@@ -188,7 +188,7 @@ function lastIndexOf<T>(object: SequenceOrArrayLike<T>, value: T, fromIndex?: nu
  *
  * #### Example
  * ```typescript
- * import { findIndex } from 'phosphor-core/lib/searching';
+ * import { findIndex } from 'phosphor/lib/algorithm/searching';
  *
  * function isEven(value: number): boolean {
  *   return value % 2 === 0;
@@ -245,7 +245,7 @@ function findIndex<T>(object: SequenceOrArrayLike<T>, fn: (value: T, index: numb
  *
  * #### Example
  * ```typescript
- * import { findLastIndex } from 'phosphor-core/lib/searching';
+ * import { findLastIndex } from 'phosphor/lib/algorithm/searching';
  *
  * function isEven(value: number): boolean {
  *   return value % 2 === 0;
@@ -305,7 +305,7 @@ function findLastIndex<T>(object: SequenceOrArrayLike<T>, fn: (value: T, index: 
  *
  * #### Example
  * ```typescript
- * import { lowerBound } from 'phosphor-core/lib/searching';
+ * import { lowerBound } from 'phosphor/lib/algorithm/searching';
  *
  * function numberCmp(a: number, b: number): number {
  *   return a - b;
@@ -369,7 +369,7 @@ function lowerBound<T, U>(object: SequenceOrArrayLike<T>, value: U, fn: (element
  *
  * #### Example
  * ```typescript
- * import { upperBound } from 'phosphor-core/lib/searching';
+ * import { upperBound } from 'phosphor/lib/algorithm/searching';
  *
  * function numberCmp(a: number, b: number): number {
  *   return a - b;

--- a/src/core/signaling.ts
+++ b/src/core/signaling.ts
@@ -32,7 +32,7 @@ type Slot<T, U> = (sender: T, args: U) => void;
  *
  * #### Example
  * ```typescript
- * import { ISignal, defineSignal } from 'phosphor-core/lib/signaling';
+ * import { ISignal, defineSignal } from 'phosphor/lib/core/signaling';
  *
  * class SomeClass {
  *

--- a/src/dom/cursor.ts
+++ b/src/dom/cursor.ts
@@ -29,7 +29,7 @@ const OVERRIDE_CURSOR_CLASS = 'p-mod-override-cursor';
  *
  * #### Example
  * ```typescript
- * import { overrideCursor } from 'phosphor-ui/lib/css-util';
+ * import { overrideCursor } from 'phosphor/lib/dom/cursor';
  *
  * // force the cursor to be 'wait' for the entire document
  * let override = overrideCursor('wait');

--- a/src/dom/sizing.ts
+++ b/src/dom/sizing.ts
@@ -73,7 +73,7 @@ interface IBoxSizing {
  *
  * #### Example
  * ```typescript
- * import { boxSizing } from 'phosphor-ui/lib/dom-util';
+ * import { boxSizing } from 'phosphor/lib/dom/sizing';
  *
  * let div = document.createElement('div');
  * div.style.borderTop = 'solid 10px black';
@@ -149,7 +149,7 @@ interface ISizeLimits {
  *
  * #### Example
  * ```typescript
- * import { sizeLimits } from 'phosphor-ui/lib/dom-util';
+ * import { sizeLimits } from 'phosphor/lib/dom/sizing';
  *
  * let div = document.createElement('div');
  * div.style.minWidth = '90px';


### PR DESCRIPTION
Fixes all references to `phosphor-ui` and `phosphor-core` in the library.

cf #50.