### PR TITLE
Allow custom command registry and keymap in command palette

### DIFF
--- a/src/ui/commandpalette.ts
+++ b/src/ui/commandpalette.ts
@@ -220,7 +220,7 @@ class CommandItem implements IDisposable {
    * All calls made after the first call to this method are a no-op.
    */
   dispose(): void {
-    // Do nothing if the drag object is already disposed.
+    // Do nothing if the command item is already disposed.
     if (this._disposed) {
       return;
     }


### PR DESCRIPTION
cf #50.

The `CommandItem` would also need to expose its `keymap` and `commands` so we can verify compatibility with the palette.  This could all be avoided if we only accepted options to create a command item, but you'd lose the ability to make custom items.