### PR TITLE
Replace widget focus/blur with activate/deactivate

### DIFF
--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -798,8 +798,8 @@ class Menu extends Widget {
     // Open the menu as a root menu.
     Private.openRootMenu(this, x, y, forceX, forceY);
 
-    // Focus the menu to accept keyboard input.
-    this.focus();
+    // Activate the menu to accept keyboard input.
+    this.activate();
   }
 
   /**
@@ -922,7 +922,7 @@ class Menu extends Widget {
       parentMenu._cancelCloseTimer();
       parentMenu._childIndex = -1;
       parentMenu._childMenu = null;
-      parentMenu.focus();
+      parentMenu.activate();
     }
 
     // Emit the `aboutToClose` signal if the menu is attached.
@@ -1225,8 +1225,8 @@ class Menu extends Widget {
       menu.activateNextItem();
     }
 
-    // Set focus to the child menu.
-    menu.focus();
+    // Activate the child menu.
+    menu.activate();
   }
 
   /**

--- a/src/ui/menubar.ts
+++ b/src/ui/menubar.ts
@@ -502,7 +502,7 @@ class MenuBar extends Widget {
     if (kc === 27) {
       this._closeChildMenu();
       this.activeIndex = -1;
-      this.node.blur();
+      this.deactivate();
       return;
     }
 

--- a/src/ui/menubar.ts
+++ b/src/ui/menubar.ts
@@ -502,7 +502,7 @@ class MenuBar extends Widget {
     if (kc === 27) {
       this._closeChildMenu();
       this.activeIndex = -1;
-      this.blur();
+      this.node.blur();
       return;
     }
 

--- a/src/ui/tabpanel.ts
+++ b/src/ui/tabpanel.ts
@@ -235,7 +235,7 @@ class TabPanel extends Widget {
     let currentWidget = currentTitle ? currentTitle.owner as Widget : null;
     if (previousWidget) previousWidget.hide();
     if (currentWidget) currentWidget.show();
-    if (currentWidget) currentWidget.focus();
+    if (currentWidget) currentWidget.activate();
     this.currentChanged.emit({
       previousIndex, previousWidget, currentIndex, currentWidget
     });

--- a/src/ui/widget.ts
+++ b/src/ui/widget.ts
@@ -382,23 +382,13 @@ class Widget implements IDisposable, IMessageHandler {
   }
 
   /**
-   * Send a `'focus-request'` message to the widget.
+   * Post an `'activate-request'` message to the widget.
    *
    * #### Notes
-   * This is a simple convenience method for sending the message.
+   * This is a simple convenience method for posting the message.
    */
-  focus(): void {
-    sendMessage(this, WidgetMessage.FocusRequest);
-  }
-
-  /**
-   * Send a `'blur-request'` message to the widget.
-   *
-   * #### Notes
-   * This is a simple convenience method for sending the message.
-   */
-  blur(): void {
-    sendMessage(this, WidgetMessage.BlurRequest);
+  activate(): void {
+    postMessage(this, WidgetMessage.ActivateRequest);
   }
 
   /**
@@ -542,13 +532,9 @@ class Widget implements IDisposable, IMessageHandler {
       this.clearFlag(WidgetFlag.IsVisible);
       this.clearFlag(WidgetFlag.IsAttached);
       break;
-    case 'focus-request':
+    case 'activate-request':
       this.notifyLayout(msg);
-      this.onFocusRequest(msg);
-      break;
-    case 'blur-request':
-      this.notifyLayout(msg);
-      this.onBlurRequest(msg);
+      this.onActivateRequest(msg);
       break;
     case 'close-request':
       this.notifyLayout(msg);
@@ -583,23 +569,13 @@ class Widget implements IDisposable, IMessageHandler {
   }
 
   /**
-   * A message handler invoked on a `'focus-request'` message.
+   * A message handler invoked on an `'activate-request'` message.
    *
    * #### Notes
    * The default implementation focuses the widget's node.
    */
-  protected onFocusRequest(msg: Message): void {
+  protected onActivateRequest(msg: Message): void {
     if (this.isAttached) this.node.focus();
-  }
-
-  /**
-   * A message handler invoked on a `'blur-request'` message.
-   *
-   * #### Notes
-   * The default implementation blurs the widget's node.
-   */
-  protected onBlurRequest(msg: Message): void {
-    if (this.isAttached) this.node.blur();
   }
 
   /**
@@ -1248,24 +1224,15 @@ namespace WidgetMessage {
   const FitRequest = new ConflatableMessage('fit-request');
 
   /**
-   * A singleton conflatable `'focus-request'` message.
+   * A singleton conflatable `'activate-request'` message.
    *
    * #### Notes
    * This message should be dispatched to a widget when it should
-   * set input focus to its node or focus delegate.
+   * perform the actions necessary to activate the widget, which
+   * may include focusing its node or descendant node.
    */
   export
-  const FocusRequest = new ConflatableMessage('focus-request');
-
-  /**
-   * A singleton conflatable `'blur-request'` message.
-   *
-   * #### Notes
-   * This message should be dispatched to a widget when it should
-   * remove input focus from its node or focus delegate.
-   */
-  export
-  const BlurRequest = new ConflatableMessage('blur-request');
+  const ActivateRequest = new ConflatableMessage('activate-request');
 
   /**
    * A singleton conflatable `'close-request'` message.

--- a/src/ui/widget.ts
+++ b/src/ui/widget.ts
@@ -392,6 +392,16 @@ class Widget implements IDisposable, IMessageHandler {
   }
 
   /**
+   * Post an `'deactivate-request'` message to the widget.
+   *
+   * #### Notes
+   * This is a simple convenience method for posting the message.
+   */
+  deactivate(): void {
+    postMessage(this, WidgetMessage.DeactivateRequest);
+  }
+
+  /**
    * Send a `'close-request'` message to the widget.
    *
    * #### Notes
@@ -536,6 +546,10 @@ class Widget implements IDisposable, IMessageHandler {
       this.notifyLayout(msg);
       this.onActivateRequest(msg);
       break;
+    case 'deactivate-request':
+      this.notifyLayout(msg);
+      this.onDeactivateRequest(msg);
+      break;
     case 'close-request':
       this.notifyLayout(msg);
       this.onCloseRequest(msg);
@@ -576,6 +590,16 @@ class Widget implements IDisposable, IMessageHandler {
    */
   protected onActivateRequest(msg: Message): void {
     if (this.isAttached) this.node.focus();
+  }
+
+  /**
+   * A message handler invoked on an `'deactivate-request'` message.
+   *
+   * #### Notes
+   * The default implementation blurs the widget's node.
+   */
+  protected onDeactivateRequest(msg: Message): void {
+    if (this.isAttached) this.node.blur();
   }
 
   /**
@@ -1233,6 +1257,17 @@ namespace WidgetMessage {
    */
   export
   const ActivateRequest = new ConflatableMessage('activate-request');
+
+  /**
+   * A singleton conflatable `'deactivate-request'` message.
+   *
+   * #### Notes
+   * This message should be dispatched to a widget when it should
+   * perform the actions necessary to decactivate the widget, which
+   * may include blurring its node or descendant node.
+   */
+  export
+  const DeactivateRequest = new ConflatableMessage('deactivate-request');
 
   /**
    * A singleton conflatable `'close-request'` message.

--- a/test/src/ui/menu.spec.ts
+++ b/test/src/ui/menu.spec.ts
@@ -1615,7 +1615,7 @@ describe('ui/menu', () => {
         menu.dispose();
       });
 
-      it('should remove the menu from its parent and focus the parent', () => {
+      it('should remove the menu from its parent and activate the parent', (done) => {
         let sub = new LogMenu();
         sub.addItem({ command: DEFAULT_CMD });
         let menu = new LogMenu();
@@ -1627,8 +1627,11 @@ describe('ui/menu', () => {
         sub.close();
         expect(sub.methods.indexOf('onCloseRequest')).to.not.be(-1);
         expect(menu.childMenu).to.be(null);
-        expect(document.activeElement).to.be(menu.node);
-        menu.dispose();
+        requestAnimationFrame(() => {
+          expect(document.activeElement).to.be(menu.node);
+          menu.dispose();
+          done();
+        });
       });
 
       it('should emit the `aboutToClose` signal if attached', () => {

--- a/test/src/ui/tabpanel.spec.ts
+++ b/test/src/ui/tabpanel.spec.ts
@@ -240,24 +240,24 @@ describe('ui/tabpanel', () => {
         panel.dispose();
       });
 
-      it('should show and focus the new widget when the current tab changes', () => {
+      it('should show and activate the new widget when the current tab changes', (done) => {
         let panel = new TabPanel();
         let widgets = [new Widget(), new Widget(), new Widget()];
         each(widgets, w => { panel.addWidget(w); });
         each(widgets, w => { w.node.tabIndex = -1; });
         Widget.attach(panel, document.body);
         let bar = panel.tabBar;
-        let called = false;
         bar.currentChanged.connect((sender, args) => {
           expect(widgets[args.previousIndex].isVisible).to.be(false);
           let widget = widgets[args.currentIndex];
           expect(widget.isVisible).to.be(true);
-          expect(widget.node.contains(document.activeElement)).to.be(true);
-          called = true;
+          requestAnimationFrame(() => {
+            expect(widget.node.contains(document.activeElement)).to.be(true);
+            panel.dispose();
+            done();
+          });
         });
         bar.currentIndex = 1;
-        expect(called).to.be(true);
-        panel.dispose();
       });
 
       it('should close the widget when a tab is closed', () => {

--- a/test/src/ui/widget.spec.ts
+++ b/test/src/ui/widget.spec.ts
@@ -46,14 +46,9 @@ class LogWidget extends Widget {
     this.methods.push('notifyLayout');
   }
 
-  protected onFocusRequest(msg: Message): void {
-    super.onFocusRequest(msg);
-    this.methods.push('onFocusRequest');
-  }
-
-  protected onBlurRequest(msg: Message): void {
-    super.onBlurRequest(msg);
-    this.methods.push('onBlurRequest');
+  protected onActivateRequest(msg: Message): void {
+    super.onActivateRequest(msg);
+    this.methods.push('onActivateRequest');
   }
 
   protected onCloseRequest(msg: Message): void {
@@ -715,24 +710,18 @@ describe('ui/widget', () => {
 
     });
 
-    describe('#focus()', () => {
+    describe('#activate()', () => {
 
-      it('should send a `focus-request` message', () => {
+      it('should post an `activate-request` message', (done) => {
         let widget = new LogWidget();
         expect(widget.messages).to.eql([]);
-        widget.focus();
-        expect(widget.messages).to.eql(['focus-request']);
-      });
-
-    });
-
-    describe('#blur()', () => {
-
-      it('should send a `blur-request` message', () => {
-        let widget = new LogWidget();
+        widget.activate();
         expect(widget.messages).to.eql([]);
-        widget.blur();
-        expect(widget.messages).to.eql(['blur-request']);
+        requestAnimationFrame(() => {
+          expect(widget.messages).to.eql(['activate-request']);
+          done();
+        });
+
       });
 
     });
@@ -902,17 +891,17 @@ describe('ui/widget', () => {
 
     });
 
-    describe('#onFocusRequest()', () => {
+    describe('#onActivateRequest()', () => {
 
-      it('should be invoked on a `focus-request', () => {
+      it('should be invoked on an `activate-request', () => {
         let widget = new LogWidget();
-        sendMessage(widget, WidgetMessage.FocusRequest);
-        expect(widget.methods.indexOf('onFocusRequest')).to.not.be(-1);
+        sendMessage(widget, WidgetMessage.ActivateRequest);
+        expect(widget.methods.indexOf('onActivateRequest')).to.not.be(-1);
       });
 
       it('should notify the layout', () => {
         let widget = new LogWidget();
-        sendMessage(widget, WidgetMessage.FocusRequest);
+        sendMessage(widget, WidgetMessage.ActivateRequest);
         expect(widget.methods.indexOf('notifyLayout')).to.not.be(-1);
       });
 
@@ -920,35 +909,8 @@ describe('ui/widget', () => {
         let widget = new Widget();
         widget.node.tabIndex = -1;
         Widget.attach(widget, document.body);
-        sendMessage(widget, WidgetMessage.FocusRequest);
+        sendMessage(widget, WidgetMessage.ActivateRequest);
         expect(document.activeElement).to.be(widget.node);
-        widget.dispose();
-      });
-
-    });
-
-    describe('#onBlurRequest()', () => {
-
-      it('should be invoked on a `blur-request', () => {
-        let widget = new LogWidget();
-        sendMessage(widget, WidgetMessage.BlurRequest);
-        expect(widget.methods.indexOf('onBlurRequest')).to.not.be(-1);
-      });
-
-      it('should notify the layout', () => {
-        let widget = new LogWidget();
-        sendMessage(widget, WidgetMessage.BlurRequest);
-        expect(widget.methods.indexOf('notifyLayout')).to.not.be(-1);
-      });
-
-      it('should blur the widget node', () => {
-        let widget = new Widget();
-        widget.node.tabIndex = -1;
-        Widget.attach(widget, document.body);
-        widget.node.focus();
-        expect(document.activeElement).to.be(widget.node);
-        sendMessage(widget, WidgetMessage.BlurRequest);
-        expect(document.activeElement).to.not.be(widget.node);
         widget.dispose();
       });
 

--- a/test/src/ui/widget.spec.ts
+++ b/test/src/ui/widget.spec.ts
@@ -51,6 +51,11 @@ class LogWidget extends Widget {
     this.methods.push('onActivateRequest');
   }
 
+  protected onDeactivateRequest(msg: Message): void {
+    super.onDeactivateRequest(msg);
+    this.methods.push('onDeactivateRequest');
+  }
+
   protected onCloseRequest(msg: Message): void {
     super.onCloseRequest(msg);
     this.methods.push('onCloseRequest');
@@ -726,6 +731,20 @@ describe('ui/widget', () => {
 
     });
 
+    describe('#deactivate()', () => {
+
+      it('should post a `deactivate-request` message', (done) => {
+        let widget = new LogWidget();
+        widget.deactivate();
+        expect(widget.messages).to.eql([]);
+        requestAnimationFrame(() => {
+          expect(widget.messages).to.eql(['deactivate-request']);
+          done();
+        });
+      });
+
+    });
+
     describe('#close()', () => {
 
       it('should send a `close-request` message', () => {
@@ -911,6 +930,33 @@ describe('ui/widget', () => {
         Widget.attach(widget, document.body);
         sendMessage(widget, WidgetMessage.ActivateRequest);
         expect(document.activeElement).to.be(widget.node);
+        widget.dispose();
+      });
+
+    });
+
+    describe('#onDeactivateRequest()', () => {
+
+      it('should be invoked on a `deactivate-request', () => {
+        let widget = new LogWidget();
+        sendMessage(widget, WidgetMessage.DeactivateRequest);
+        expect(widget.methods.indexOf('onDeactivateRequest')).to.not.be(-1);
+      });
+
+      it('should notify the layout', () => {
+        let widget = new LogWidget();
+        sendMessage(widget, WidgetMessage.DeactivateRequest);
+        expect(widget.methods.indexOf('notifyLayout')).to.not.be(-1);
+      });
+
+      it('should blur the widget node', () => {
+        let widget = new Widget();
+        widget.node.tabIndex = -1;
+        Widget.attach(widget, document.body);
+        widget.node.focus();
+        expect(document.activeElement).to.be(widget.node);
+        sendMessage(widget, WidgetMessage.DeactivateRequest);
+        expect(document.activeElement).to.not.be(widget.node);
         widget.dispose();
       });
 


### PR DESCRIPTION
We deemed `focus/blur` to be the wrong semantic action, and instead decided to use `activate/deactivate`, where the default action is to focus/blur the widget.  

This also makes the messages conflatable.