### PR TITLE
Remove unused private property.

### DIFF
--- a/src/core/token.ts
+++ b/src/core/token.ts
@@ -54,5 +54,4 @@ class Token<T> {
   }
 
   private _name: string;
-  private _tokenStructuralPropertyT: T;
 }


### PR DESCRIPTION
`private _tokenStructuralPropertyT: T;` was not being used.