### PR TITLE
Add directories.lib config to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
     "ui",
     "widget"
   ],
+  "directories": {
+    "lib": "lib/"
+  },
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
   "contributors": [
     "A. Darian <git@darian.af>",


### PR DESCRIPTION
Used to "Tell people where the bulk of your library is. Nothing special is done with the lib folder in any way, but it's useful meta info."
https://docs.npmjs.com/files/package.json#directorieslib

We plan to use this in JupyterLab as the place to look for source files if a `main` is not given.

cf https://github.com/jupyter/jupyterlab/issues/224#issuecomment-241551346