### PR TITLE
only delete node.dataset['command'] if defined

### DIFF
--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -1423,9 +1423,9 @@ namespace Menu {
 
       // Set the command ID in the data set.
       if (item.type === 'command') {
-        node.dataset['command'] = item.command;
+        node.setAttribute('data-command', item.command);
       } else {
-        delete node.dataset['command'];
+        node.removeAttribute('data-command');
       }
 
       // Update the rest of the node state.


### PR DESCRIPTION
Deleting undefined properties raises an error in Safari

[Docs suggest](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/delete) that deleting should raise in some cases in strict mode, but Safari is the only browser that seems to raise for this particular case. I can't actually tell if the documented case for raising should apply or not.

cf jupyter/jupyterlab#749