### PR TITLE
Edge case that causes horizontal scrollbar in menu.

### DIFF
--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -1660,7 +1660,7 @@ namespace Private {
     Widget.attach(menu, document.body);
 
     // Expand the menu width by the scrollbar size, if present.
-    if (node.scrollHeight > maxHeight) {
+    if (node.scrollHeight >= maxHeight) {
       style.width = `${2 * node.offsetWidth - node.clientWidth}px`;
     }
 


### PR DESCRIPTION
When `int(scroll height)` is exactly equal to `int(max menu height)`, a vertical scrollbar needs to be accounted for. This may well be a rounding error, but the effective fix is to check for `>=` instead of just `>`.
