### PR TITLE
Switch to using strict null checks

### DIFF
--- a/src/algorithm/iteration.ts
+++ b/src/algorithm/iteration.ts
@@ -63,7 +63,7 @@ interface IIterator<T> extends IIterable<T> {
    * an object allocation on each iteration; and an `isDone()` method
    * increases implementation and runtime complexity.
    */
-  next(): T;
+  next(): T | undefined;
 }
 
 
@@ -131,7 +131,7 @@ function iter<T>(object: IterableOrArrayLike<T>): IIterator<T> {
  */
 export
 function toArray<T>(object: IterableOrArrayLike<T>): T[] {
-  let value: T;
+  let value: T | undefined;
   let result: T[] = [];
   let it = iter(object);
   while ((value = it.next()) !== void 0) {
@@ -174,7 +174,7 @@ class EmptyIterator<T> implements IIterator<T> {
    *
    * @returns Always `undefined`.
    */
-  next(): T {
+  next(): T | undefined {
     return void 0;
   }
 }
@@ -240,7 +240,7 @@ class ArrayIterator<T> implements IIterator<T> {
    * @returns The next value from the source array, or `undefined`
    *   if the iterator is exhausted.
    */
-  next(): T {
+  next(): T | undefined {
     if (this._index >= this._source.length) {
       return void 0;
     }
@@ -264,7 +264,7 @@ class ArrayIterator<T> implements IIterator<T> {
  */
 export
 function each<T>(object: IterableOrArrayLike<T>, fn: (value: T) => void): void {
-  let value: T;
+  let value: T | undefined;
   let it = iter(object);
   while ((value = it.next()) !== void 0) {
     fn(value);
@@ -286,7 +286,7 @@ function each<T>(object: IterableOrArrayLike<T>, fn: (value: T) => void): void {
  */
 export
 function every<T>(object: IterableOrArrayLike<T>, fn: (value: T) => boolean): boolean {
-  let value: T;
+  let value: T | undefined;
   let it = iter(object);
   while ((value = it.next()) !== void 0) {
     if (!fn(value)) return false;
@@ -309,7 +309,7 @@ function every<T>(object: IterableOrArrayLike<T>, fn: (value: T) => boolean): bo
  */
 export
 function some<T>(object: IterableOrArrayLike<T>, fn: (value: T) => boolean): boolean {
-  let value: T;
+  let value: T | undefined;
   let it = iter(object);
   while ((value = it.next()) !== void 0) {
     if (fn(value)) return true;
@@ -385,7 +385,7 @@ function reduce<T>(object: IterableOrArrayLike<T>, fn: (accumulator: any, value:
   }
 
   // Iterate the rest of the values, updating the accumulator.
-  let next: T;
+  let next: T | undefined;
   while ((next = it.next()) !== void 0) {
     accumulator = fn(accumulator, next);
   }
@@ -457,8 +457,8 @@ class FilterIterator<T> implements IIterator<T> {
    * @returns The next value from the source iterator which passes
    *   the predicate, or `undefined` if the iterator is exhausted.
    */
-  next(): T {
-    let value: T;
+  next(): T | undefined {
+    let value: T | undefined;
     let fn = this._fn;
     let it = this._source;
     while ((value = it.next()) !== void 0) {
@@ -534,7 +534,7 @@ class MapIterator<T, U> implements IIterator<U> {
    * @returns The next value from the source iterator transformed
    *   by the mapper, or `undefined` if the iterator is exhausted.
    */
-  next(): U {
+  next(): U | undefined {
     let value = this._source.next();
     if (value === void 0) {
       return void 0;
@@ -606,7 +606,7 @@ class EnumerateIterator<T> implements IIterator<[number, T]> {
    * @returns The next value from the enumeration, or `undefined` if
    *   the iterator is exhausted.
    */
-  next(): [number, T] {
+  next(): [number, T] | undefined {
     let value = this._source.next();
     if (value === void 0) {
       return void 0;
@@ -675,7 +675,7 @@ class ZipIterator<T> implements IIterator<T[]> {
    * @returns The next zipped value from the iterator, or `undefined`
    *   when the first source iterator is exhausted.
    */
-  next(): T[] {
+  next(): T[] | undefined {
     let iters = this._source;
     let result = new Array<T>(iters.length);
     for (let i = 0, n = iters.length; i < n; ++i) {
@@ -753,7 +753,7 @@ class StrideIterator<T> implements IIterator<T> {
    * @returns The next stepped value from the iterator, or `undefined`
    *   when the source iterator is exhausted.
    */
-  next(): T {
+  next(): T | undefined {
     let value = this._source.next();
     if (value === void 0) {
       return void 0;

--- a/src/algorithm/json.ts
+++ b/src/algorithm/json.ts
@@ -25,7 +25,7 @@ type JSONValue = JSONPrimitive | JSONObject | JSONArray;
  * A type definition for a JSON object.
  */
 export
-interface JSONObject { [key: string]: JSONValue; }
+interface JSONObject { [key: string]: JSONValue | undefined; }
 
 
 /**

--- a/src/algorithm/json.ts
+++ b/src/algorithm/json.ts
@@ -11,7 +11,7 @@
  * A type alias for a JSON primitive.
  */
 export
-type JSONPrimitive = boolean | number | string;
+type JSONPrimitive = boolean | number | string | null;
 
 
 /**

--- a/src/algorithm/range.ts
+++ b/src/algorithm/range.ts
@@ -186,7 +186,7 @@ class RangeIterator implements IIterator<number> {
    * @returns The next value from the range, or `undefined` if the
    *   iterator is exhausted.
    */
-  next(): number {
+  next(): number | undefined {
     if (this._index >= this._length) {
       return void 0;
     }

--- a/src/algorithm/searching.ts
+++ b/src/algorithm/searching.ts
@@ -47,8 +47,8 @@ import {
  * ```
  */
 export
-function find<T>(object: IterableOrArrayLike<T>, fn: (value: T) => boolean): T {
-  let value: T;
+function find<T>(object: IterableOrArrayLike<T>, fn: (value: T) => boolean): T | undefined {
+  let value: T | undefined;
   let it = iter(object);
   while ((value = it.next()) !== void 0) {
     if (fn(value)) {
@@ -88,13 +88,13 @@ function find<T>(object: IterableOrArrayLike<T>, fn: (value: T) => boolean): T {
  * ```
  */
 export
-function min<T>(object: IterableOrArrayLike<T>, fn: (first: T, second: T) => number): T {
+function min<T>(object: IterableOrArrayLike<T>, fn: (first: T, second: T) => number): T | undefined {
   let it = iter(object);
   let result = it.next();
   if (result === void 0) {
     return void 0;
   }
-  let value: T;
+  let value: T | undefined;
   while ((value = it.next()) !== void 0) {
     if (fn(value, result) < 0) {
       result = value;
@@ -133,13 +133,13 @@ function min<T>(object: IterableOrArrayLike<T>, fn: (first: T, second: T) => num
  * ```
  */
 export
-function max<T>(object: IterableOrArrayLike<T>, fn: (first: T, second: T) => number): T {
+function max<T>(object: IterableOrArrayLike<T>, fn: (first: T, second: T) => number): T | undefined {
   let it = iter(object);
   let result = it.next();
   if (result === void 0) {
     return void 0;
   }
-  let value: T;
+  let value: T | undefined;
   while ((value = it.next()) !== void 0) {
     if (fn(value, result) > 0) {
       result = value;
@@ -546,7 +546,7 @@ namespace StringSearch {
    * required, the text should be transformed before scoring.
    */
   export
-  function sumOfSquares(sourceText: string, queryText: string): ISumOfSquaresResult {
+  function sumOfSquares(sourceText: string, queryText: string): ISumOfSquaresResult | null {
     let score = 0;
     let indices = new Array<number>(queryText.length);
     for (let i = 0, j = 0, n = queryText.length; i < n; ++i, ++j) {

--- a/src/collections/deque.ts
+++ b/src/collections/deque.ts
@@ -75,7 +75,7 @@ class Deque<T> implements IIterable<T> {
    * #### Iterator Validity
    * No changes.
    */
-  get front(): T {
+  get front(): T | undefined {
     return this._front ? this._front.value : void 0;
   }
 
@@ -94,7 +94,7 @@ class Deque<T> implements IIterable<T> {
    * #### Iterator Validity
    * No changes.
    */
-  get back(): T {
+  get back(): T | undefined {
     return this._back ? this._back.value : void 0;
   }
 
@@ -133,7 +133,7 @@ class Deque<T> implements IIterable<T> {
       this._back = node;
     } else {
       node.next = this._front;
-      this._front.prev = node;
+      this._front!.prev = node;
       this._front = node;
     }
     return ++this._length;
@@ -159,7 +159,7 @@ class Deque<T> implements IIterable<T> {
       this._back = node;
     } else {
       node.prev = this._back;
-      this._back.next = node;
+      this._back!.next = node;
       this._back = node;
     }
     return ++this._length;
@@ -177,17 +177,17 @@ class Deque<T> implements IIterable<T> {
    * #### Iterator Validity
    * Iterators pointing at the removed value are invalidated.
    */
-  popFront(): T {
+  popFront(): T | undefined {
     if (this._length === 0) {
       return void 0;
     }
-    let node = this._front;
+    let node = this._front!;
     if (this._length === 1) {
       this._front = null;
       this._back = null;
     } else {
       this._front = node.next;
-      this._front.prev = null;
+      this._front!.prev = null;
       node.next = null;
     }
     this._length--;
@@ -206,17 +206,17 @@ class Deque<T> implements IIterable<T> {
    * #### Iterator Validity
    * Iterators pointing at the removed value are invalidated.
    */
-  popBack(): T {
+  popBack(): T | undefined {
     if (this._length === 0) {
       return void 0;
     }
-    let node = this._back;
+    let node = this._back!;
     if (this._length === 1) {
       this._front = null;
       this._back = null;
     } else {
       this._back = node.prev;
-      this._back.next = null;
+      this._back!.next = null;
       node.prev = null;
     }
     this._length--;
@@ -270,8 +270,8 @@ class Deque<T> implements IIterable<T> {
   }
 
   private _length = 0;
-  private _front: DequeNode<T> = null;
-  private _back: DequeNode<T> = null;
+  private _front: DequeNode<T> | null = null;
+  private _back: DequeNode<T> | null = null;
 }
 
 
@@ -284,7 +284,7 @@ class DequeIterator<T> implements IIterator<T> {
    *
    * @param node - The node at the front of range.
    */
-  constructor(node: DequeNode<T>) {
+  constructor(node: DequeNode<T> | null) {
     this._node = node;
   }
 
@@ -312,7 +312,7 @@ class DequeIterator<T> implements IIterator<T> {
    * @returns The next value from the deque, or `undefined` if the
    *   iterator is exhausted.
    */
-  next(): T {
+  next(): T | undefined {
     if (!this._node) {
       return void 0;
     }
@@ -321,7 +321,7 @@ class DequeIterator<T> implements IIterator<T> {
     return value;
   }
 
-  private _node: DequeNode<T>;
+  private _node: DequeNode<T> | null;
 }
 
 
@@ -332,12 +332,12 @@ class DequeNode<T> {
   /**
    * The next node the deque.
    */
-  next: DequeNode<T> = null;
+  next: DequeNode<T> | null = null;
 
   /**
    * The previous node in the deque.
    */
-  prev: DequeNode<T> = null;
+  prev: DequeNode<T> | null = null;
 
   /**
    * The value for the node.

--- a/src/collections/queue.ts
+++ b/src/collections/queue.ts
@@ -75,7 +75,7 @@ class Queue<T> implements IIterable<T> {
    * #### Iterator Validity
    * No changes.
    */
-  get front(): T {
+  get front(): T | undefined {
     return this._front ? this._front.value : void 0;
   }
 
@@ -94,7 +94,7 @@ class Queue<T> implements IIterable<T> {
    * #### Iterator Validity
    * No changes.
    */
-  get back(): T {
+  get back(): T | undefined {
     return this._back ? this._back.value : void 0;
   }
 
@@ -132,7 +132,7 @@ class Queue<T> implements IIterable<T> {
       this._front = node;
       this._back = node;
     } else {
-      this._back.next = node;
+      this._back!.next = node;
       this._back = node;
     }
     return ++this._length;
@@ -150,11 +150,11 @@ class Queue<T> implements IIterable<T> {
    * #### Iterator Validity
    * Iterators pointing at the removed value are invalidated.
    */
-  popFront(): T {
+  popFront(): T | undefined {
     if (this._length === 0) {
       return void 0;
     }
-    let node = this._front;
+    let node = this._front!;
     if (this._length === 1) {
       this._front = null;
       this._back = null;
@@ -212,8 +212,8 @@ class Queue<T> implements IIterable<T> {
   }
 
   private _length = 0;
-  private _front: QueueNode<T> = null;
-  private _back: QueueNode<T> = null;
+  private _front: QueueNode<T> | null = null;
+  private _back: QueueNode<T> | null = null;
 }
 
 
@@ -226,7 +226,7 @@ class QueueIterator<T> implements IIterator<T> {
    *
    * @param node - The node at the front of range.
    */
-  constructor(node: QueueNode<T>) {
+  constructor(node: QueueNode<T> | null) {
     this._node = node;
   }
 
@@ -254,7 +254,7 @@ class QueueIterator<T> implements IIterator<T> {
    * @returns The next value from the queue, or `undefined` if the
    *   iterator is exhausted.
    */
-  next(): T {
+  next(): T | undefined {
     if (!this._node) {
       return void 0;
     }
@@ -263,7 +263,7 @@ class QueueIterator<T> implements IIterator<T> {
     return value;
   }
 
-  private _node: QueueNode<T>;
+  private _node: QueueNode<T> | null;
 }
 
 
@@ -274,7 +274,7 @@ class QueueNode<T> {
   /**
    * The next node the queue.
    */
-  next: QueueNode<T> = null;
+  next: QueueNode<T> | null = null;
 
   /**
    * The value for the node.

--- a/src/collections/stack.ts
+++ b/src/collections/stack.ts
@@ -123,7 +123,7 @@ class Stack<T> implements IIterable<T> {
    * #### Iterator Validity
    * Iterators pointing at the removed value are invalidated.
    */
-  popBack(): T {
+  popBack(): T | undefined {
     return this._array.pop();
   }
 
@@ -202,7 +202,7 @@ class StackIterator<T> implements IIterator<T> {
    * @returns The next value from the stack, or `undefined` if the
    *   iterator is exhausted.
    */
-  next(): T {
+  next(): T | undefined {
     if (this._index < 0 || this._index >= this._array.length) {
       return void 0;
     }

--- a/src/collections/vector.ts
+++ b/src/collections/vector.ts
@@ -186,7 +186,7 @@ class Vector<T> implements IMutableSequence<T> {
    * #### Iterator Validity
    * Iterators pointing at the removed value are invalidated.
    */
-  popBack(): T {
+  popBack(): T | undefined {
     return this._array.pop();
   }
 
@@ -262,7 +262,7 @@ class Vector<T> implements IMutableSequence<T> {
    * #### Undefined Behavior
    * An `index` which is non-integral.
    */
-  removeAt(index: number): T {
+  removeAt(index: number): T | undefined {
     let array = this._array;
     let n = array.length;
     if (index < 0 || index >= n) {

--- a/src/core/disposable.ts
+++ b/src/core/disposable.ts
@@ -75,7 +75,7 @@ class DisposableDelegate implements IDisposable {
     callback();
   }
 
-  private _callback: () => void;
+  private _callback: (() => void) | null;
 }
 
 
@@ -90,7 +90,7 @@ class DisposableSet implements IDisposable {
    * @param items - The initial disposable items.
    */
   constructor(items?: IterableOrArrayLike<IDisposable>) {
-    if (items) each(items, item => { this._set.add(item); });
+    if (items) each(items, item => { this._set!.add(item); });
   }
 
   /**
@@ -164,5 +164,5 @@ class DisposableSet implements IDisposable {
     this._set.clear();
   }
 
-  private _set = new Set<IDisposable>();
+  private _set: Set<IDisposable> | null = new Set<IDisposable>();
 }

--- a/src/core/messaging.ts
+++ b/src/core/messaging.ts
@@ -345,7 +345,7 @@ namespace MessageLoop {
     }
 
     // Conflate message if possible.
-    let conflated = some(queue, posted => {
+    let conflated = some(queue, (posted: PostedMessage) => {
       if (posted.handler !== handler) {
         return false;
       }
@@ -431,7 +431,8 @@ namespace MessageLoop {
   /**
    * A type alias for a posted message pair.
    */
-  type PostedMessage = { handler: IMessageHandler, msg: Message };
+  type PostedMessage = { handler: IMessageHandler | null, msg: Message };
+  type PostedMessageSentinel = { handler: IMessageHandler | null, msg: Message | null};
 
   /**
    * A type alias for a node in a message hook list.
@@ -441,7 +442,7 @@ namespace MessageLoop {
   /**
    * The queue of posted message pairs.
    */
-  const queue = new Queue<PostedMessage>();
+  const queue = new Queue<PostedMessage | PostedMessageSentinel>();
 
   /**
    * A mapping of handler to list of installed message hooks.
@@ -533,7 +534,7 @@ namespace MessageLoop {
     // Add a sentinel value to the end of the queue. The queue will
     // only be processed up to the sentinel. Messages posted during
     // this cycle will execute on the next cycle.
-    let sentinel: PostedMessage = { handler: null, msg: null };
+    let sentinel: PostedMessageSentinel = { handler: null, msg: null };
     queue.pushBack(sentinel);
 
     // Enter the message loop.
@@ -548,7 +549,7 @@ namespace MessageLoop {
 
       // Dispatch the message if the handler has not been cleared.
       if (posted.handler !== null) {
-        sendMessage(posted.handler, posted.msg);
+        sendMessage(posted.handler, posted.msg!);
       }
     }
   }

--- a/src/core/messaging.ts
+++ b/src/core/messaging.ts
@@ -387,7 +387,7 @@ namespace MessageLoop {
     // the reference to the hook and remove the node from the list.
     // The node's next reference is *not* cleared so that dispatch
     // may continue when the hook is removed during dispatch.
-    let prev: HookNode = null;
+    let prev: HookNode | null = null;
     let node = hooks.get(handler) || null;
     for (; node !== null; prev = node, node = node.next) {
       if (node.hook === hook) {
@@ -436,7 +436,7 @@ namespace MessageLoop {
   /**
    * A type alias for a node in a message hook list.
    */
-  type HookNode = { next: HookNode, hook: MessageHook };
+  type HookNode = { next: HookNode, hook: MessageHook | null };
 
   /**
    * The queue of posted message pairs.
@@ -539,7 +539,7 @@ namespace MessageLoop {
     // Enter the message loop.
     while (!queue.isEmpty) {
       // Remove the first posted message in the queue.
-      let posted = queue.popFront();
+      let posted = queue.popFront()!;
 
       // If the value is the sentinel, exit the loop.
       if (posted === sentinel) {

--- a/src/core/properties.ts
+++ b/src/core/properties.ts
@@ -135,8 +135,8 @@ class AttachedProperty<T, U> {
    * If the value has not yet been set, the default value will be
    * computed and assigned as the current value of the property.
    */
-  get(owner: T): U {
-    let value: U;
+  get(owner: T): U | undefined {
+    let value: U | undefined;
     let map = ensureMap(owner);
     if (this._pid in map) {
       value = map[this._pid];
@@ -157,8 +157,8 @@ class AttachedProperty<T, U> {
    * If the value has not yet been set, the default value will be
    * computed and used as the previous value for the comparison.
    */
-  set(owner: T, value: U): void {
-    let oldValue: U;
+  set(owner: T, value: U | undefined): void {
+    let oldValue: U | undefined;
     let map = ensureMap(owner);
     if (this._pid in map) {
       oldValue = map[this._pid];
@@ -179,7 +179,7 @@ class AttachedProperty<T, U> {
    * computed and used as the previous value for the comparison.
    */
   coerce(owner: T): void {
-    let oldValue: U;
+    let oldValue: U | undefined;
     let map = ensureMap(owner);
     if (this._pid in map) {
       oldValue = map[this._pid];
@@ -193,7 +193,7 @@ class AttachedProperty<T, U> {
   /**
    * Get or create the default value for the given owner.
    */
-  private _createValue(owner: T): U {
+  private _createValue(owner: T): U | undefined {
     let create = this._create;
     return create ? create(owner) : this._value;
   }
@@ -201,7 +201,7 @@ class AttachedProperty<T, U> {
   /**
    * Coerce the value for the given owner.
    */
-  private _coerceValue(owner: T, value: U): U {
+  private _coerceValue(owner: T, value: U | undefined): U | undefined {
     let coerce = this._coerce;
     return coerce ? coerce(owner, value) : value;
   }
@@ -209,7 +209,7 @@ class AttachedProperty<T, U> {
   /**
    * Compare the old value and new value for equality.
    */
-  private _compareValue(oldValue: U, newValue: U): boolean {
+  private _compareValue(oldValue: U | undefined, newValue: U | undefined): boolean {
     let compare = this._compare;
     return compare ? compare(oldValue, newValue) : oldValue === newValue;
   }
@@ -217,20 +217,20 @@ class AttachedProperty<T, U> {
   /**
    * Run the change notification if the given values are different.
    */
-  private _maybeNotify(owner: T, oldValue: U, newValue: U): void {
+  private _maybeNotify(owner: T, oldValue: U | undefined, newValue: U | undefined): void {
     if (!this._changed || this._compareValue(oldValue, newValue)) {
       return;
     }
     this._changed.call(void 0, owner, oldValue, newValue);
   }
 
-  private _value: U;
+  private _value: U | undefined;
   private _name: string;
   private _pid = nextPID();
-  private _create: (owner: T) => U;
-  private _coerce: (owner: T, value: U) => U;
-  private _compare: (oldValue: U, newValue: U) => boolean;
-  private _changed: (owner: T, oldValue: U, newValue: U) => void;
+  private _create: ((owner: T) => U) | undefined;
+  private _coerce: ((owner: T, value: U | undefined) => U | undefined) | undefined;
+  private _compare: ((oldValue: U | undefined, newValue: U | undefined) => boolean) | undefined;
+  private _changed: ((owner: T, oldValue: U | undefined, newValue: U | undefined) => void) | undefined;
 }
 
 

--- a/src/core/signaling.ts
+++ b/src/core/signaling.ts
@@ -558,7 +558,7 @@ function invokeSlot(conn: IConnection, args: any): void {
  * @returns The first connection which matches the supplied parameters,
  *   or null if no matching connection is found.
  */
-function findConnection(list: IConnection[], token: any, slot: Slot<any, any>, thisArg: any): IConnection {
+function findConnection(list: IConnection[], token: any, slot: Slot<any, any>, thisArg: any): IConnection | null {
   for (let i = 0, n = list.length; i < n; ++i) {
     let conn = list[i];
     if (conn.token === token &&

--- a/src/dom/cursor.ts
+++ b/src/dom/cursor.ts
@@ -39,7 +39,7 @@ const OVERRIDE_CURSOR_CLASS = 'p-mod-override-cursor';
  * ```
  */
 export
-function overrideCursor(cursor: string): IDisposable {
+function overrideCursor(cursor: string | null): IDisposable {
   let id = ++Private.cursorID;
   let body = document.body;
   body.style.cursor = cursor;

--- a/src/dom/dragdrop.ts
+++ b/src/dom/dragdrop.ts
@@ -703,7 +703,7 @@ namespace Private {
   function createMouseEvent(type: string, clientX: number, clientY: number): MouseEvent {
     let event = document.createEvent('MouseEvent');
     event.initMouseEvent(type, true, true, window, 0, 0, 0,
-      clientX, clientY, false, false, false, false, 0, null);
+      clientX, clientY, false, false, false, false, 0, null!);
     return event;
   }
 
@@ -905,7 +905,7 @@ namespace Private {
       event.clientX, event.clientY,
       event.ctrlKey, event.altKey,
       event.shiftKey, event.metaKey,
-      event.button, related
+      event.button, related! // Workaround: Related can be null, but lib.d.ts typings are incorrect
     );
 
     // Add the custom drag event data.

--- a/src/dom/dragdrop.ts
+++ b/src/dom/dragdrop.ts
@@ -55,7 +55,7 @@ interface IDragEvent extends MouseEvent {
    * This property should be considered read-only, but for performance
    * reasons this is not enforced.
    */
-  mimeData: MimeData;
+  mimeData: MimeData | null;
 
   /**
    * The drop action supported or taken by the drop target.
@@ -207,7 +207,7 @@ class Drag implements IDisposable {
    * #### Notes
    * This is a read-only property.
    */
-  get mimeData(): MimeData {
+  get mimeData(): MimeData | null {
     return this._mimeData;
   }
 
@@ -217,7 +217,7 @@ class Drag implements IDisposable {
    * #### Notes
    * This is a read-only property.
    */
-  get dragImage(): HTMLElement {
+  get dragImage(): HTMLElement | null {
     return this._dragImage;
   }
 

--- a/src/dom/dragdrop.ts
+++ b/src/dom/dragdrop.ts
@@ -728,7 +728,7 @@ namespace Private {
    * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model
    */
   export
-  function dispatchDragEnter(drag: Drag, currElem: Element, currTarget: Element | null, event: MouseEvent): Element | null {
+  function dispatchDragEnter(drag: Drag, currElem: Element | null, currTarget: Element | null, event: MouseEvent): Element | null {
     // If the current element is null, return null as the new target.
     if (!currElem) {
       return null;
@@ -838,7 +838,7 @@ namespace Private {
    * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model
    */
   export
-  function dispatchDrop(drag: Drag, currTarget: Element, event: MouseEvent): DropAction {
+  function dispatchDrop(drag: Drag, currTarget: Element | null, event: MouseEvent): DropAction {
     // If there is no current target, the drop action is none.
     if (!currTarget) {
       return 'none';

--- a/src/dom/dragdrop.ts
+++ b/src/dom/dragdrop.ts
@@ -583,16 +583,16 @@ class Drag implements IDisposable {
 
   private _disposed = false;
   private _source: any = null;
-  private _mimeData: MimeData = null;
-  private _dragImage: HTMLElement = null;
+  private _mimeData: MimeData | null = null;
+  private _dragImage: HTMLElement | null = null;
   private _dropAction: DropAction = 'none';
   private _proposedAction: DropAction = 'copy';
   private _supportedActions: SupportedActions = 'all';
-  private _override: IDisposable = null;
-  private _currentTarget: Element = null;
-  private _currentElement: Element = null;
-  private _promise: Promise<DropAction> = null;
-  private _resolve: (value: DropAction) => void = null;
+  private _override: IDisposable | null = null;
+  private _currentTarget: Element | null = null;
+  private _currentElement: Element | null = null;
+  private _promise: Promise<DropAction> | null = null;
+  private _resolve: ((value: DropAction) => void) | null = null;
 }
 
 
@@ -728,7 +728,7 @@ namespace Private {
    * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model
    */
   export
-  function dispatchDragEnter(drag: Drag, currElem: Element, currTarget: Element, event: MouseEvent): Element {
+  function dispatchDragEnter(drag: Drag, currElem: Element, currTarget: Element | null, event: MouseEvent): Element | null {
     // If the current element is null, return null as the new target.
     if (!currElem) {
       return null;
@@ -774,7 +774,7 @@ namespace Private {
    * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model
    */
   export
-  function dispatchDragLeave(drag: Drag, prevTarget: Element, currTarget: Element, event: MouseEvent): void {
+  function dispatchDragLeave(drag: Drag, prevTarget: Element | null, currTarget: Element | null, event: MouseEvent): void {
     // If the previous target is null, do nothing.
     if (!prevTarget) {
       return;
@@ -802,7 +802,7 @@ namespace Private {
    * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model
    */
   export
-  function dispatchDragOver(drag: Drag, currTarget: Element, event: MouseEvent): DropAction {
+  function dispatchDragOver(drag: Drag, currTarget: Element | null, event: MouseEvent): DropAction {
     // If there is no current target, the drop action is none.
     if (!currTarget) {
       return 'none';
@@ -894,7 +894,7 @@ namespace Private {
    *
    * @returns A new object which implements `IDragEvent`.
    */
-  function createDragEvent(type: string, drag: Drag, event: MouseEvent, related: Element): IDragEvent {
+  function createDragEvent(type: string, drag: Drag, event: MouseEvent, related: Element | null): IDragEvent {
     // Create a new mouse event and cast to a custom drag event.
     let dragEvent = document.createEvent('MouseEvent') as IDragEvent;
 

--- a/src/dom/dragdrop.ts
+++ b/src/dom/dragdrop.ts
@@ -55,7 +55,7 @@ interface IDragEvent extends MouseEvent {
    * This property should be considered read-only, but for performance
    * reasons this is not enforced.
    */
-  mimeData: MimeData | null;
+  mimeData: MimeData;
 
   /**
    * The drop action supported or taken by the drop target.
@@ -207,7 +207,7 @@ class Drag implements IDisposable {
    * #### Notes
    * This is a read-only property.
    */
-  get mimeData(): MimeData | null {
+  get mimeData(): MimeData {
     return this._mimeData;
   }
 
@@ -566,7 +566,7 @@ class Drag implements IDisposable {
     // Clear the internal drag state.
     this._disposed = true;
     this._source = null;
-    this._mimeData = null;
+    this._mimeData = null!; // Do not null type check
     this._dragImage = null;
     this._dropAction = 'none';
     this._proposedAction = 'none';
@@ -583,7 +583,7 @@ class Drag implements IDisposable {
 
   private _disposed = false;
   private _source: any = null;
-  private _mimeData: MimeData | null = null;
+  private _mimeData: MimeData;
   private _dragImage: HTMLElement | null = null;
   private _dropAction: DropAction = 'none';
   private _proposedAction: DropAction = 'copy';
@@ -910,7 +910,7 @@ namespace Private {
 
     // Add the custom drag event data.
     dragEvent.dropAction = 'none';
-    dragEvent.mimeData = drag.mimeData;
+    dragEvent.mimeData = drag.mimeData!;
     dragEvent.proposedAction = drag.proposedAction;
     dragEvent.supportedActions = drag.supportedActions;
     dragEvent.source = drag.source;

--- a/src/dom/sizing.ts
+++ b/src/dom/sizing.ts
@@ -88,14 +88,15 @@ interface IBoxSizing {
 export
 function boxSizing(node: HTMLElement): IBoxSizing {
   let cstyle = window.getComputedStyle(node);
-  let bt = parseInt(cstyle.borderTopWidth, 10) || 0;
-  let bl = parseInt(cstyle.borderLeftWidth, 10) || 0;
-  let br = parseInt(cstyle.borderRightWidth, 10) || 0;
-  let bb = parseInt(cstyle.borderBottomWidth, 10) || 0;
-  let pt = parseInt(cstyle.paddingTop, 10) || 0;
-  let pl = parseInt(cstyle.paddingLeft, 10) || 0;
-  let pr = parseInt(cstyle.paddingRight, 10) || 0;
-  let pb = parseInt(cstyle.paddingBottom, 10) || 0;
+  // Override null type check as all values have `|| <number>`:
+  let bt = parseInt(cstyle.borderTopWidth!, 10) || 0;
+  let bl = parseInt(cstyle.borderLeftWidth!, 10) || 0;
+  let br = parseInt(cstyle.borderRightWidth!, 10) || 0;
+  let bb = parseInt(cstyle.borderBottomWidth!, 10) || 0;
+  let pt = parseInt(cstyle.paddingTop!, 10) || 0;
+  let pl = parseInt(cstyle.paddingLeft!, 10) || 0;
+  let pr = parseInt(cstyle.paddingRight!, 10) || 0;
+  let pb = parseInt(cstyle.paddingBottom!, 10) || 0;
   let hs = bl + pl + pr + br;
   let vs = bt + pt + pb + bb;
   return {
@@ -165,9 +166,10 @@ export
 function sizeLimits(node: HTMLElement): ISizeLimits {
   let cstyle = window.getComputedStyle(node);
   return {
-    minWidth: parseInt(cstyle.minWidth, 10) || 0,
-    minHeight: parseInt(cstyle.minHeight, 10) || 0,
-    maxWidth: parseInt(cstyle.maxWidth, 10) || Infinity,
-    maxHeight: parseInt(cstyle.maxHeight, 10) || Infinity
+    // Override null type check as all values have `|| <number>`:
+    minWidth: parseInt(cstyle.minWidth!, 10) || 0,
+    minHeight: parseInt(cstyle.minHeight!, 10) || 0,
+    maxWidth: parseInt(cstyle.maxWidth!, 10) || Infinity,
+    maxHeight: parseInt(cstyle.maxHeight!, 10) || Infinity
   };
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "ES5",
-    "outDir": "../lib"
+    "outDir": "../lib",
+    "strictNullChecks": true
   }
 }

--- a/src/ui/application.ts
+++ b/src/ui/application.ts
@@ -371,10 +371,10 @@ abstract class Application<T extends Widget> {
   }
 
   private _started = false;
-  private _shell: T = null;
+  private _shell: T | null = null;
   private _keymap: Keymap;
   private _commands: CommandRegistry;
-  private _promise: Promise<void> = null;
+  private _promise: Promise<void> | null = null;
   private _pluginMap = Private.createPluginMap();
   private _serviceMap = Private.createServiceMap();
 }
@@ -519,7 +519,7 @@ namespace Private {
     /**
      * The type of service provided by the plugin, or `null`.
      */
-    provides: Token<any>;
+    provides: Token<any> | null;
 
     /**
      * The function which activates the plugin.
@@ -534,12 +534,12 @@ namespace Private {
     /**
      * The resolved service for the plugin, or `null`.
      */
-    service: any;
+    service: any | null;
 
     /**
      * The pending resolver promise, or `null`.
      */
-    promise: Promise<void>;
+    promise: Promise<void> | null;
   }
 
   /**

--- a/src/ui/application.ts
+++ b/src/ui/application.ts
@@ -57,7 +57,7 @@ abstract class Application<T extends Widget> {
    *
    * This is a read-only property.
    */
-  get shell(): T {
+  get shell(): T | null {
     return this._shell;
   }
 

--- a/src/ui/application.ts
+++ b/src/ui/application.ts
@@ -328,7 +328,7 @@ abstract class Application<T extends Widget> {
    * A subclass may reimplement this method as needed.
    */
   protected attachShell(id: string): void {
-    Widget.attach(this.shell, document.getElementById(id) || document.body);
+    Widget.attach(this.shell!, document.getElementById(id) || document.body);
   }
 
   /**
@@ -367,7 +367,7 @@ abstract class Application<T extends Widget> {
    * A subclass may reimplement this method as needed.
    */
   protected evtResize(event: Event): void {
-    this.shell.update();
+    this.shell!.update();
   }
 
   private _started = false;

--- a/src/ui/boxpanel.ts
+++ b/src/ui/boxpanel.ts
@@ -307,13 +307,13 @@ class BoxLayout extends PanelLayout {
     Widget.prepareGeometry(widget);
 
     // Add the widget's node to the parent.
-    this.parent.node.appendChild(widget.node);
+    this.parent!.node!.appendChild(widget.node!);
 
     // Send an `'after-attach'` message if the parent is attached.
-    if (this.parent.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
+    if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
 
     // Post a layout request for the parent widget.
-    this.parent.fit();
+    this.parent!.fit();
   }
 
   /**
@@ -333,7 +333,7 @@ class BoxLayout extends PanelLayout {
     move(this._sizers, fromIndex, toIndex);
 
     // Post an update request for the parent widget.
-    this.parent.update();
+    this.parent!.update();
   }
 
   /**
@@ -351,16 +351,16 @@ class BoxLayout extends PanelLayout {
     this._sizers.removeAt(index);
 
     // Send a `'before-detach'` message if the parent is attached.
-    if (this.parent.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
+    if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
 
     // Remove the widget's node from the parent.
-    this.parent.node.removeChild(widget.node);
+    this.parent!.node!.removeChild(widget.node!);
 
     // Reset the layout geometry for the widget.
     Widget.resetGeometry(widget);
 
     // Post a layout request for the parent widget.
-    this.parent.fit();
+    this.parent!.fit();
   }
 
   /**
@@ -370,7 +370,7 @@ class BoxLayout extends PanelLayout {
    * This is called when the layout is installed on its parent.
    */
   protected onLayoutChanged(msg: Message): void {
-    Private.toggleDirection(this.parent, this.direction);
+    Private.toggleDirection(this.parent!, this.direction);
     super.onLayoutChanged(msg);
   }
 
@@ -379,7 +379,7 @@ class BoxLayout extends PanelLayout {
    */
   protected onAfterShow(msg: Message): void {
     super.onAfterShow(msg);
-    this.parent.update();
+    this.parent!.update();
   }
 
   /**
@@ -387,7 +387,7 @@ class BoxLayout extends PanelLayout {
    */
   protected onAfterAttach(msg: Message): void {
     super.onAfterAttach(msg);
-    this.parent.fit();
+    this.parent!.fit();
   }
 
   /**
@@ -395,9 +395,9 @@ class BoxLayout extends PanelLayout {
    */
   protected onChildShown(msg: ChildMessage): void {
     if (IS_IE) { // prevent flicker on IE
-      sendMessage(this.parent, WidgetMessage.FitRequest);
+      sendMessage(this.parent!, WidgetMessage.FitRequest);
     } else {
-      this.parent.fit();
+      this.parent!.fit();
     }
   }
 
@@ -406,9 +406,9 @@ class BoxLayout extends PanelLayout {
    */
   protected onChildHidden(msg: ChildMessage): void {
     if (IS_IE) { // prevent flicker on IE
-      sendMessage(this.parent, WidgetMessage.FitRequest);
+      sendMessage(this.parent!, WidgetMessage.FitRequest);
     } else {
-      this.parent.fit();
+      this.parent!.fit();
     }
   }
 
@@ -416,7 +416,7 @@ class BoxLayout extends PanelLayout {
    * A message handler invoked on a `'resize'` message.
    */
   protected onResize(msg: ResizeMessage): void {
-    if (this.parent.isVisible) {
+    if (this.parent!.isVisible) {
       this._update(msg.width, msg.height);
     }
   }
@@ -425,7 +425,7 @@ class BoxLayout extends PanelLayout {
    * A message handler invoked on an `'update-request'` message.
    */
   protected onUpdateRequest(msg: Message): void {
-    if (this.parent.isVisible) {
+    if (this.parent!.isVisible) {
       this._update(-1, -1);
     }
   }
@@ -434,7 +434,7 @@ class BoxLayout extends PanelLayout {
    * A message handler invoked on a `'fit-request'` message.
    */
   protected onFitRequest(msg: Message): void {
-    if (this.parent.isAttached) {
+    if (this.parent!.isAttached) {
       this._fit();
     }
   }
@@ -476,7 +476,7 @@ class BoxLayout extends PanelLayout {
         sizer.maxSize = 0;
         continue;
       }
-      let limits = sizeLimits(widget.node);
+      let limits = sizeLimits(widget.node!);
       sizer.sizeHint = BoxLayout.getSizeBasis(widget);
       sizer.stretch = BoxLayout.getStretch(widget);
       if (horz) {
@@ -497,14 +497,14 @@ class BoxLayout extends PanelLayout {
     }
 
     // Update the box sizing and add it to the size constraints.
-    let box = this._box = boxSizing(this.parent.node);
+    let box = this._box = boxSizing(this.parent!.node!);
     minW += box.horizontalSum;
     minH += box.verticalSum;
     maxW += box.horizontalSum;
     maxH += box.verticalSum;
 
     // Update the parent's size constraints.
-    let style = this.parent.node.style;
+    let style = this.parent!.node!.style;
     style.minWidth = `${minW}px`;
     style.minHeight = `${minH}px`;
     style.maxWidth = maxW === Infinity ? 'none' : `${maxW}px`;
@@ -515,12 +515,12 @@ class BoxLayout extends PanelLayout {
 
     // Notify the ancestor that it should fit immediately. This may
     // cause a resize of the parent, fulfilling the required update.
-    let ancestor = this.parent.parent;
+    let ancestor = this.parent!.parent;
     if (ancestor) sendMessage(ancestor, WidgetMessage.FitRequest);
 
     // If the dirty flag is still set, the parent was not resized.
     // Trigger the required update on the parent widget immediately.
-    if (this._dirty) sendMessage(this.parent, WidgetMessage.UpdateRequest);
+    if (this._dirty) sendMessage(this.parent!, WidgetMessage.UpdateRequest);
   }
 
   /**
@@ -540,14 +540,14 @@ class BoxLayout extends PanelLayout {
 
     // Measure the parent if the offset dimensions are unknown.
     if (offsetWidth < 0) {
-      offsetWidth = this.parent.node.offsetWidth;
+      offsetWidth = this.parent!.node!.offsetWidth;
     }
     if (offsetHeight < 0) {
-      offsetHeight = this.parent.node.offsetHeight;
+      offsetHeight = this.parent!.node!.offsetHeight;
     }
 
     // Ensure the parent box sizing data is computed.
-    let box = this._box || (this._box = boxSizing(this.parent.node));
+    let box = this._box || (this._box = boxSizing(this.parent!.node!));
 
     // Compute the layout area adjusted for border and padding.
     let top = box.paddingTop;
@@ -760,6 +760,6 @@ namespace Private {
   function onChildPropertyChanged(child: Widget): void {
     let parent = child.parent;
     let layout = parent && parent.layout;
-    if (layout instanceof BoxLayout) parent.fit();
+    if (layout instanceof BoxLayout) parent!.fit();
   }
 }

--- a/src/ui/boxpanel.ts
+++ b/src/ui/boxpanel.ts
@@ -604,7 +604,7 @@ class BoxLayout extends PanelLayout {
   private _fixed = 0;
   private _spacing = 4;
   private _dirty = false;
-  private _box: IBoxSizing = null;
+  private _box: IBoxSizing | null = null;
   private _sizers = new Vector<BoxSizer>();
   private _direction: BoxLayout.Direction = 'top-to-bottom';
 }
@@ -652,7 +652,7 @@ namespace BoxLayout {
    */
   export
   function getStretch(widget: Widget): number {
-    return Private.stretchProperty.get(widget);
+    return Private.stretchProperty.get(widget)!;
   }
 
   /**
@@ -676,7 +676,7 @@ namespace BoxLayout {
    */
   export
   function getSizeBasis(widget: Widget): number {
-    return Private.sizeBasisProperty.get(widget);
+    return Private.sizeBasisProperty.get(widget)!;
   }
 
   /**

--- a/src/ui/boxpanel.ts
+++ b/src/ui/boxpanel.ts
@@ -307,7 +307,7 @@ class BoxLayout extends PanelLayout {
     Widget.prepareGeometry(widget);
 
     // Add the widget's node to the parent.
-    this.parent!.node!.appendChild(widget.node!);
+    this.parent!.node.appendChild(widget.node);
 
     // Send an `'after-attach'` message if the parent is attached.
     if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
@@ -354,7 +354,7 @@ class BoxLayout extends PanelLayout {
     if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
 
     // Remove the widget's node from the parent.
-    this.parent!.node!.removeChild(widget.node!);
+    this.parent!.node.removeChild(widget.node);
 
     // Reset the layout geometry for the widget.
     Widget.resetGeometry(widget);
@@ -476,7 +476,7 @@ class BoxLayout extends PanelLayout {
         sizer.maxSize = 0;
         continue;
       }
-      let limits = sizeLimits(widget.node!);
+      let limits = sizeLimits(widget.node);
       sizer.sizeHint = BoxLayout.getSizeBasis(widget);
       sizer.stretch = BoxLayout.getStretch(widget);
       if (horz) {
@@ -497,14 +497,14 @@ class BoxLayout extends PanelLayout {
     }
 
     // Update the box sizing and add it to the size constraints.
-    let box = this._box = boxSizing(this.parent!.node!);
+    let box = this._box = boxSizing(this.parent!.node);
     minW += box.horizontalSum;
     minH += box.verticalSum;
     maxW += box.horizontalSum;
     maxH += box.verticalSum;
 
     // Update the parent's size constraints.
-    let style = this.parent!.node!.style;
+    let style = this.parent!.node.style;
     style.minWidth = `${minW}px`;
     style.minHeight = `${minH}px`;
     style.maxWidth = maxW === Infinity ? 'none' : `${maxW}px`;
@@ -540,14 +540,14 @@ class BoxLayout extends PanelLayout {
 
     // Measure the parent if the offset dimensions are unknown.
     if (offsetWidth < 0) {
-      offsetWidth = this.parent!.node!.offsetWidth;
+      offsetWidth = this.parent!.node.offsetWidth;
     }
     if (offsetHeight < 0) {
-      offsetHeight = this.parent!.node!.offsetHeight;
+      offsetHeight = this.parent!.node.offsetHeight;
     }
 
     // Ensure the parent box sizing data is computed.
-    let box = this._box || (this._box = boxSizing(this.parent!.node!));
+    let box = this._box || (this._box = boxSizing(this.parent!.node));
 
     // Compute the layout area adjusted for border and padding.
     let top = box.paddingTop;
@@ -759,7 +759,6 @@ namespace Private {
    */
   function onChildPropertyChanged(child: Widget): void {
     let parent = child.parent;
-    let layout = parent && parent.layout;
-    if (layout instanceof BoxLayout) parent!.fit();
+    if (parent && parent.layout instanceof BoxLayout) parent.fit();
   }
 }

--- a/src/ui/commandpalette.ts
+++ b/src/ui/commandpalette.ts
@@ -137,9 +137,10 @@ class CommandPalette extends Widget {
     this._itemNodes.clear();
     this._headerNodes.clear();
     this._result = null;
-    this._keymap = null;
-    this._commands = null;
-    this._renderer = null;
+    // Do not use null type checking for these:
+    this._keymap = null!;
+    this._commands = null!;
+    this._renderer = null!;
     super.dispose();
   }
 
@@ -152,7 +153,7 @@ class CommandPalette extends Widget {
    * This is a read-only property.
    */
   get searchNode(): HTMLDivElement {
-    return this.node!.getElementsByClassName(SEARCH_CLASS)[0] as HTMLDivElement;
+    return this.node.getElementsByClassName(SEARCH_CLASS)[0] as HTMLDivElement;
   }
 
   /**
@@ -162,7 +163,7 @@ class CommandPalette extends Widget {
    * This is a read-only property.
    */
   get inputNode(): HTMLInputElement {
-    return this.node!.getElementsByClassName(INPUT_CLASS)[0] as HTMLInputElement;
+    return this.node.getElementsByClassName(INPUT_CLASS)[0] as HTMLInputElement;
   }
 
   /**
@@ -176,7 +177,7 @@ class CommandPalette extends Widget {
    * This is a read-only property.
    */
   get contentNode(): HTMLUListElement {
-    return this.node!.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
+    return this.node.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
   }
 
   /**
@@ -195,7 +196,7 @@ class CommandPalette extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get commands(): CommandRegistry | null {
+  get commands(): CommandRegistry {
     return this._commands;
   }
 
@@ -205,7 +206,7 @@ class CommandPalette extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get keymap(): Keymap | null {
+  get keymap(): Keymap {
     return this._keymap;
   }
 
@@ -215,7 +216,7 @@ class CommandPalette extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get renderer(): CommandPalette.IRenderer | null {
+  get renderer(): CommandPalette.IRenderer {
     return this._renderer;
   }
 
@@ -228,7 +229,7 @@ class CommandPalette extends Widget {
    */
   addItem(options: CommandPalette.IItemOptions): CommandPalette.IItem {
     // Create a new command item for the options.
-    let item = Private.createItem(this._commands!, this._keymap!, options);
+    let item = Private.createItem(this._commands, this._keymap, options);
 
     // Add the item to the vector.
     this._items.pushBack(item);
@@ -318,10 +319,9 @@ class CommandPalette extends Widget {
    * A message handler invoked on a `'after-attach'` message.
    */
   protected onAfterAttach(msg: Message): void {
-    let node = this.node!;
-    node.addEventListener('click', this);
-    node.addEventListener('keydown', this);
-    node.addEventListener('input', this);
+    this.node.addEventListener('click', this);
+    this.node.addEventListener('keydown', this);
+    this.node.addEventListener('input', this);
     this.update();
   }
 
@@ -329,10 +329,9 @@ class CommandPalette extends Widget {
    * A message handler invoked on a `'before-detach'` message.
    */
   protected onBeforeDetach(msg: Message): void {
-    let node = this.node!;
-    node.removeEventListener('click', this);
-    node.removeEventListener('keydown', this);
-    node.removeEventListener('input', this);
+    this.node.removeEventListener('click', this);
+    this.node.removeEventListener('keydown', this);
+    this.node.removeEventListener('input', this);
   }
 
   /**
@@ -385,7 +384,7 @@ class CommandPalette extends Widget {
     }
 
     // Fetch command variables.
-    let renderer = this._renderer!;
+    let renderer = this._renderer;
     let itemNodes = this._itemNodes;
     let headerNodes = this._headerNodes;
 
@@ -647,7 +646,7 @@ class CommandPalette extends Widget {
     if (part.item) {
       input.focus();
       input.select();
-      this._commands!.execute(part.item.command, part.item.args);
+      this._commands.execute(part.item.command, part.item.args);
       return;
     }
 
@@ -679,9 +678,9 @@ class CommandPalette extends Widget {
   }
 
   private _activeIndex = 1;
-  private _keymap: Keymap | null;
-  private _commands: CommandRegistry | null;
-  private _renderer: CommandPalette.IRenderer | null;
+  private _keymap: Keymap;
+  private _commands: CommandRegistry;
+  private _renderer: CommandPalette.IRenderer;
   private _itemNodes = new Vector<HTMLLIElement>();
   private _headerNodes = new Vector<HTMLLIElement>();
   private _items = new Vector<CommandPalette.IItem>();

--- a/src/ui/commandpalette.ts
+++ b/src/ui/commandpalette.ts
@@ -262,7 +262,7 @@ class CommandPalette extends Widget {
    * @returns The item occupying the index, or `null` if the index
    *   is out of range.
    */
-  removeItemAt(index: number): CommandPalette.IItem {
+  removeItemAt(index: number): CommandPalette.IItem | null {
     // Bail if the index is out of range.
     let i = Math.floor(index);
     if (i < 0 || i >= this._items.length) {
@@ -270,7 +270,7 @@ class CommandPalette extends Widget {
     }
 
     // Remove the item from the vector.
-    let item = this._items.removeAt(index);
+    let item = this._items.removeAt(index)!;
 
     // Schedule an update of the content.
     if (this.isAttached) this.update();
@@ -677,13 +677,13 @@ class CommandPalette extends Widget {
   }
 
   private _activeIndex = 1;
-  private _keymap: Keymap;
-  private _commands: CommandRegistry;
-  private _renderer: CommandPalette.IRenderer;
+  private _keymap: Keymap | null;
+  private _commands: CommandRegistry | null;
+  private _renderer: CommandPalette.IRenderer | null;
   private _itemNodes = new Vector<HTMLLIElement>();
   private _headerNodes = new Vector<HTMLLIElement>();
   private _items = new Vector<CommandPalette.IItem>();
-  private _result: Private.ISearchResult = null;
+  private _result: Private.ISearchResult | null = null;
 }
 
 
@@ -730,7 +730,7 @@ namespace CommandPalette {
      *
      * The default value is `null`.
      */
-    args?: JSONObject;
+    args?: JSONObject | null;
 
     /**
      * The category for the item.
@@ -756,7 +756,7 @@ namespace CommandPalette {
     /**
      * The arguments for the command.
      */
-    args: JSONObject;
+    args: JSONObject | null;
 
     /**
      * The category for the command item.
@@ -968,7 +968,7 @@ namespace CommandPalette {
      *
      * @returns The formatted shortcut text for display.
      */
-    formatShortcut(binding: Keymap.IBinding): string {
+    formatShortcut(binding: Keymap.IBinding | null): string {
       return binding ? binding.keys.map(Keymap.formatKeystroke).join(' ') : '';
     }
   }
@@ -1048,7 +1048,7 @@ namespace Private {
      *
      * This is `null` for a header part.
      */
-    item: CommandPalette.IItem;
+    item: CommandPalette.IItem | null;
   }
 
   /**
@@ -1168,7 +1168,7 @@ namespace Private {
     /**
      * The arguments for the command.
      */
-    get args(): JSONObject {
+    get args(): JSONObject | null {
       return this._args;
     }
 
@@ -1231,7 +1231,7 @@ namespace Private {
     private _commands: CommandRegistry;
     private _keymap: Keymap;
     private _command: string;
-    private _args: JSONObject;
+    private _args: JSONObject | null;
     private _category: string;
   }
 
@@ -1252,7 +1252,7 @@ namespace Private {
     /**
      * The indices of the matched characters.
      */
-    indices: number[];
+    indices: number[] | null;
   }
 
   /**
@@ -1517,7 +1517,7 @@ namespace Private {
    *
    * @returns The text interpolated with `<mark>` tags as needed.
    */
-  function highlightText(text: string, indices: number[]): string {
+  function highlightText(text: string, indices: number[] | null): string {
     return indices ? StringSearch.highlight(text, indices) : text;
   }
 }

--- a/src/ui/commandpalette.ts
+++ b/src/ui/commandpalette.ts
@@ -195,7 +195,7 @@ class CommandPalette extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get commands(): CommandRegistry {
+  get commands(): CommandRegistry | null {
     return this._commands;
   }
 
@@ -205,7 +205,7 @@ class CommandPalette extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get keymap(): Keymap {
+  get keymap(): Keymap | null {
     return this._keymap;
   }
 
@@ -215,7 +215,7 @@ class CommandPalette extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get renderer(): CommandPalette.IRenderer {
+  get renderer(): CommandPalette.IRenderer | null {
     return this._renderer;
   }
 
@@ -796,7 +796,7 @@ namespace CommandPalette {
     /**
      * The key binding for the command item.
      */
-    keyBinding: Keymap.IBinding;
+    keyBinding: Keymap.IBinding | null;
   }
 
   /**
@@ -1224,7 +1224,7 @@ namespace Private {
     /**
      * The key binding for the command item.
      */
-    get keyBinding(): Keymap.IBinding {
+    get keyBinding(): Keymap.IBinding | null {
       return this._keymap.findBinding(this._command, this._args);
     }
 

--- a/src/ui/commandpalette.ts
+++ b/src/ui/commandpalette.ts
@@ -152,7 +152,7 @@ class CommandPalette extends Widget {
    * This is a read-only property.
    */
   get searchNode(): HTMLDivElement {
-    return this.node.getElementsByClassName(SEARCH_CLASS)[0] as HTMLDivElement;
+    return this.node!.getElementsByClassName(SEARCH_CLASS)[0] as HTMLDivElement;
   }
 
   /**
@@ -162,7 +162,7 @@ class CommandPalette extends Widget {
    * This is a read-only property.
    */
   get inputNode(): HTMLInputElement {
-    return this.node.getElementsByClassName(INPUT_CLASS)[0] as HTMLInputElement;
+    return this.node!.getElementsByClassName(INPUT_CLASS)[0] as HTMLInputElement;
   }
 
   /**
@@ -176,7 +176,7 @@ class CommandPalette extends Widget {
    * This is a read-only property.
    */
   get contentNode(): HTMLUListElement {
-    return this.node.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
+    return this.node!.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
   }
 
   /**
@@ -228,7 +228,7 @@ class CommandPalette extends Widget {
    */
   addItem(options: CommandPalette.IItemOptions): CommandPalette.IItem {
     // Create a new command item for the options.
-    let item = Private.createItem(this._commands, this._keymap, options);
+    let item = Private.createItem(this._commands!, this._keymap!, options);
 
     // Add the item to the vector.
     this._items.pushBack(item);
@@ -318,9 +318,10 @@ class CommandPalette extends Widget {
    * A message handler invoked on a `'after-attach'` message.
    */
   protected onAfterAttach(msg: Message): void {
-    this.node.addEventListener('click', this);
-    this.node.addEventListener('keydown', this);
-    this.node.addEventListener('input', this);
+    let node = this.node!;
+    node.addEventListener('click', this);
+    node.addEventListener('keydown', this);
+    node.addEventListener('input', this);
     this.update();
   }
 
@@ -328,9 +329,10 @@ class CommandPalette extends Widget {
    * A message handler invoked on a `'before-detach'` message.
    */
   protected onBeforeDetach(msg: Message): void {
-    this.node.removeEventListener('click', this);
-    this.node.removeEventListener('keydown', this);
-    this.node.removeEventListener('input', this);
+    let node = this.node!;
+    node.removeEventListener('click', this);
+    node.removeEventListener('keydown', this);
+    node.removeEventListener('input', this);
   }
 
   /**
@@ -383,7 +385,7 @@ class CommandPalette extends Widget {
     }
 
     // Fetch command variables.
-    let renderer = this._renderer;
+    let renderer = this._renderer!;
     let itemNodes = this._itemNodes;
     let headerNodes = this._headerNodes;
 
@@ -645,7 +647,7 @@ class CommandPalette extends Widget {
     if (part.item) {
       input.focus();
       input.select();
-      this._commands.execute(part.item.command, part.item.args);
+      this._commands!.execute(part.item.command, part.item.args);
       return;
     }
 

--- a/src/ui/commandregistry.ts
+++ b/src/ui/commandregistry.ts
@@ -123,7 +123,7 @@ class CommandRegistry {
    * #### Notes
    * Returns an empty string if the command is not registered.
    */
-  label(id: string, args: JSONObject): string {
+  label(id: string, args: JSONObject | null): string {
     let cmd = this._commands[id];
     return cmd ? cmd.label.call(void 0, args) : '';
   }
@@ -140,7 +140,7 @@ class CommandRegistry {
    * #### Notes
    * Returns `-1` if the command is not registered.
    */
-  mnemonic(id: string, args: JSONObject): number {
+  mnemonic(id: string, args: JSONObject | null): number {
     let cmd = this._commands[id];
     return cmd ? cmd.mnemonic.call(void 0, args) : -1;
   }
@@ -157,7 +157,7 @@ class CommandRegistry {
    * #### Notes
    * Returns an empty string if the command is not registered.
    */
-  icon(id: string, args: JSONObject): string {
+  icon(id: string, args: JSONObject | null): string {
     let cmd = this._commands[id];
     return cmd ? cmd.icon.call(void 0, args) : '';
   }
@@ -174,7 +174,7 @@ class CommandRegistry {
    * #### Notes
    * Returns an empty string if the command is not registered.
    */
-  caption(id: string, args: JSONObject): string {
+  caption(id: string, args: JSONObject | null): string {
     let cmd = this._commands[id];
     return cmd ? cmd.caption.call(void 0, args) : '';
   }
@@ -191,7 +191,7 @@ class CommandRegistry {
    * #### Notes
    * Returns an empty string if the command is not registered.
    */
-  usage(id: string, args: JSONObject): string {
+  usage(id: string, args: JSONObject | null): string {
     let cmd = this._commands[id];
     return cmd ? cmd.usage.call(void 0, args) : '';
   }
@@ -208,7 +208,7 @@ class CommandRegistry {
    * #### Notes
    * Returns an empty string if the command is not registered.
    */
-  className(id: string, args: JSONObject): string {
+  className(id: string, args: JSONObject | null): string {
     let cmd = this._commands[id];
     return cmd ? cmd.className.call(void 0, args) : '';
   }
@@ -225,7 +225,7 @@ class CommandRegistry {
    * #### Notes
    * Returns `false` if the command is not registered.
    */
-  isEnabled(id: string, args: JSONObject): boolean {
+  isEnabled(id: string, args: JSONObject | null): boolean {
     let cmd = this._commands[id];
     return cmd ? cmd.isEnabled.call(void 0, args) : false;
   }
@@ -242,7 +242,7 @@ class CommandRegistry {
    * #### Notes
    * Returns `false` if the command is not registered.
    */
-  isToggled(id: string, args: JSONObject): boolean {
+  isToggled(id: string, args: JSONObject | null): boolean {
     let cmd = this._commands[id];
     return cmd ? cmd.isToggled.call(void 0, args) : false;
   }
@@ -259,7 +259,7 @@ class CommandRegistry {
    * #### Notes
    * Returns `false` if the command is not registered.
    */
-  isVisible(id: string, args: JSONObject): boolean {
+  isVisible(id: string, args: JSONObject | null): boolean {
     let cmd = this._commands[id];
     return cmd ? cmd.isVisible.call(void 0, args) : false;
   }
@@ -276,7 +276,7 @@ class CommandRegistry {
    * #### Notes
    * The promise will reject if the command is not registered.
    */
-  execute(id: string, args: JSONObject): Promise<any> {
+  execute(id: string, args: JSONObject | null): Promise<any> {
     // Reject if the command is not registered.
     let cmd = this._commands[id];
     if (!cmd) {
@@ -344,7 +344,7 @@ namespace CommandRegistry {
     /**
      * The arguments object passed to the command.
      */
-    args: JSONObject;
+    args: JSONObject | null;
   }
 
   /**
@@ -355,7 +355,7 @@ namespace CommandRegistry {
    * @returns The command result, a promise to the result, or void.
    */
   export
-  type ExecFunc = (args: JSONObject) => any;
+  type ExecFunc = (args: JSONObject | null) => any;
 
   /**
    * A type alias for a command string function.
@@ -365,7 +365,7 @@ namespace CommandRegistry {
    * @returns The relevant string result.
    */
   export
-  type StringFunc = (args: JSONObject) => string;
+  type StringFunc = (args: JSONObject | null) => string;
 
   /**
    * A type alias for a command number function.
@@ -375,7 +375,7 @@ namespace CommandRegistry {
    * @returns The relevant number result.
    */
   export
-  type NumberFunc = (args: JSONObject) => number;
+  type NumberFunc = (args: JSONObject | null) => number;
 
   /**
    * A type alias for a command boolean function.
@@ -385,7 +385,7 @@ namespace CommandRegistry {
    * @returns The relevant boolean result.
    */
   export
-  type BoolFunc = (args: JSONObject) => boolean;
+  type BoolFunc = (args: JSONObject | null) => boolean;
 
   /**
    * An options object for creating a command.
@@ -590,22 +590,22 @@ namespace Private {
   /**
    * A singleton empty string function.
    */
-  const emptyStringFunc: StringFunc = (args: JSONObject) => '';
+  const emptyStringFunc: StringFunc = (args: JSONObject | null) => '';
 
   /**
    * A singleton `-1` number function
    */
-  const negativeOneFunc: NumberFunc = (args: JSONObject) => -1;
+  const negativeOneFunc: NumberFunc = (args: JSONObject | null) => -1;
 
   /**
    * A singleton true boolean function.
    */
-  const trueFunc: BoolFunc = (args: JSONObject) => true;
+  const trueFunc: BoolFunc = (args: JSONObject | null) => true;
 
   /**
    * A singleton false boolean function.
    */
-  const falseFunc: BoolFunc = (args: JSONObject) => false;
+  const falseFunc: BoolFunc = (args: JSONObject | null) => false;
 
   /**
    * Coerce a value to a string function.
@@ -617,7 +617,7 @@ namespace Private {
     if (typeof value === 'function') {
       return value;
     }
-    return (args: JSONObject) => value as string;
+    return (args: JSONObject | null) => value as string;
   }
 
   /**
@@ -630,6 +630,6 @@ namespace Private {
     if (typeof value === 'function') {
       return value;
     }
-    return (args: JSONObject) => value as number;
+    return (args: JSONObject | null) => value as number;
   }
 }

--- a/src/ui/dockpanel.ts
+++ b/src/ui/dockpanel.ts
@@ -139,7 +139,7 @@ class DockPanel extends Widget {
     this._tracker.currentChanged.connect(this._onCurrentChanged, this);
 
     // Add the overlay node to the panel.
-    this.node.appendChild(this._overlay.node);
+    this.node!.appendChild(this._overlay.node);
   }
 
   /**
@@ -245,7 +245,7 @@ class DockPanel extends Widget {
     }
 
     // Ensure the widget is the current widget.
-    (widget.parent.parent as TabPanel).currentWidget = widget;
+    (widget.parent!.parent as TabPanel).currentWidget = widget;
 
     // Activate the widget.
     widget.activate();
@@ -314,7 +314,7 @@ class DockPanel extends Widget {
    */
   findDropTarget(clientX: number, clientY: number): DockPanel.IDropTarget {
     // If the position is not over the dock panel, bail.
-    if (!hitTest(this.node, clientX, clientY)) {
+    if (!hitTest(this.node!, clientX, clientY)) {
       return { zone: 'invalid', panel: null };
     }
 
@@ -324,19 +324,19 @@ class DockPanel extends Widget {
     }
 
     // Test for a root zone first.
-    let zone = Private.getRootZone(this.node, clientX, clientY);
+    let zone = Private.getRootZone(this.node!, clientX, clientY);
     if (zone !== 'invalid') {
       return { zone, panel: null };
     }
 
     // Find the panel at the client position.
     let panel = find(this._tabPanels, panel => {
-      return hitTest(panel.node, clientX, clientY);
+      return hitTest(panel.node!, clientX, clientY);
     }) || null;
 
     // Compute the zone for the hit panel, if any.
     if (panel) {
-      zone = Private.getPanelZone(panel.node, clientX, clientY);
+      zone = Private.getPanelZone(panel.node!, clientX, clientY);
     } else {
       zone = 'invalid';
     }
@@ -375,8 +375,8 @@ class DockPanel extends Widget {
     let right: number;
     let bottom: number;
     let cr: ClientRect;
-    let box = boxSizing(this.node); // TODO cache this?
-    let rect = this.node.getBoundingClientRect();
+    let box = boxSizing(this.node!); // TODO cache this?
+    let rect = this.node!.getBoundingClientRect();
 
     // Compute the overlay geometry based on the dock zone.
     switch (target.zone) {
@@ -411,35 +411,35 @@ class DockPanel extends Widget {
       bottom = box.paddingBottom;
       break;
     case 'panel-top':
-      cr = target.panel.node.getBoundingClientRect();
+      cr = target.panel!.node!.getBoundingClientRect();
       top = cr.top - rect.top - box.borderTop;
       left = cr.left - rect.left - box.borderLeft;
       right = rect.right - cr.right - box.borderRight;
       bottom = rect.bottom - cr.bottom + cr.height / 2 - box.borderBottom;
       break;
     case 'panel-left':
-      cr = target.panel.node.getBoundingClientRect();
+      cr = target.panel!.node!.getBoundingClientRect();
       top = cr.top - rect.top - box.borderTop;
       left = cr.left - rect.left - box.borderLeft;
       right = rect.right - cr.right + cr.width / 2 - box.borderRight;
       bottom = rect.bottom - cr.bottom - box.borderBottom;
       break;
     case 'panel-right':
-      cr = target.panel.node.getBoundingClientRect();
+      cr = target.panel!.node!.getBoundingClientRect();
       top = cr.top - rect.top - box.borderTop;
       left = cr.left - rect.left + cr.width / 2 - box.borderLeft;
       right = rect.right - cr.right - box.borderRight;
       bottom = rect.bottom - cr.bottom - box.borderBottom;
       break;
     case 'panel-bottom':
-      cr = target.panel.node.getBoundingClientRect();
+      cr = target.panel!.node!.getBoundingClientRect();
       top = cr.top - rect.top + cr.height / 2 - box.borderTop;
       left = cr.left - rect.left - box.borderLeft;
       right = rect.right - cr.right - box.borderRight;
       bottom = rect.bottom - cr.bottom - box.borderBottom;
       break;
     case 'panel-center':
-      cr = target.panel.node.getBoundingClientRect();
+      cr = target.panel!.node!.getBoundingClientRect();
       top = cr.top - rect.top - box.borderTop;
       left = cr.left - rect.left - box.borderLeft;
       right = rect.right - cr.right - box.borderRight;
@@ -497,7 +497,7 @@ class DockPanel extends Widget {
    * A message handler invoked on an `'after-attach'` message.
    */
   protected onAfterAttach(msg: Message): void {
-    let node = this.node;
+    let node = this.node!;
     node.addEventListener('p-dragenter', this);
     node.addEventListener('p-dragleave', this);
     node.addEventListener('p-dragover', this);
@@ -508,7 +508,7 @@ class DockPanel extends Widget {
    * A message handler invoked on a `'before-detach'` message.
    */
   protected onBeforeDetach(msg: Message): void {
-    let node = this.node;
+    let node = this.node!;
     node.removeEventListener('p-dragenter', this);
     node.removeEventListener('p-dragleave', this);
     node.removeEventListener('p-dragover', this);
@@ -521,7 +521,7 @@ class DockPanel extends Widget {
   private _evtDragEnter(event: IDragEvent): void {
     // If the factory mime type is present, mark the event as
     // handled in order to get the rest of the drag events.
-    if (event.mimeData.hasData(FACTORY_MIME)) {
+    if (event.mimeData!.hasData(FACTORY_MIME)) {
       event.preventDefault();
       event.stopPropagation();
     }
@@ -539,7 +539,7 @@ class DockPanel extends Widget {
     let related = event.relatedTarget as HTMLElement;
 
     // Hide the overlay if the drag is leaving the dock panel.
-    if (!related || !this.node.contains(related)) {
+    if (!related || !this.node!.contains(related)) {
       this._overlay.hide(0);
     }
   }
@@ -588,7 +588,7 @@ class DockPanel extends Widget {
     }
 
     // Bail if the factory mime type has invalid data.
-    let factory = event.mimeData.getData(FACTORY_MIME);
+    let factory = event.mimeData!.getData(FACTORY_MIME);
     if (typeof factory !== 'function') {
       event.dropAction = 'none';
       return;
@@ -639,7 +639,7 @@ class DockPanel extends Widget {
     // Otherwise, it's a panel drop, and that requires more checks.
 
     // Fetch the children of the target panel.
-    let children = target.panel.widgets;
+    let children = target.panel!.widgets;
 
     // Do nothing if the widget is dropped as a tab on its own panel.
     if (target.zone === 'panel-center' && indexOf(children, widget) !== -1) {
@@ -694,7 +694,7 @@ class DockPanel extends Widget {
     // Handle the simple case of adding to a tab panel.
     if (mode === 'tab-before' || mode === 'tab-after') {
       if (ref) {
-        let tabPanel = ref.parent.parent as TabPanel;
+        let tabPanel = ref.parent!.parent as TabPanel;
         let index = indexOf(tabPanel.widgets, ref) + (after ? 1 : 0);
         tabPanel.insertWidget(index, widget);
       } else {
@@ -735,7 +735,7 @@ class DockPanel extends Widget {
     }
 
     // Lookup the tab panel for the ref widget.
-    let refTabPanel = ref.parent.parent as TabPanel;
+    let refTabPanel = ref.parent!.parent as TabPanel;
 
     // If the ref tab panel is the root, split the root.
     if (this._root === refTabPanel) {
@@ -789,8 +789,8 @@ class DockPanel extends Widget {
   private _createTabPanel(): TabPanel {
     let panel = new TabPanel({ tabsMovable: true });
     panel.addClass(TAB_PANEL_CLASS);
-    panel.tabBar.tabDetachRequested.connect(this._onTabDetachRequested, this);
-    panel.stackedPanel.widgetRemoved.connect(this._onWidgetRemoved, this);
+    panel.tabBar!.tabDetachRequested.connect(this._onTabDetachRequested, this);
+    panel.stackedPanel!.widgetRemoved.connect(this._onWidgetRemoved, this);
     this._tabPanels.pushBack(panel);
     return panel;
   }
@@ -840,7 +840,7 @@ class DockPanel extends Widget {
     // Otherwise, use the tab panel of the current widget if possible.
     let current = this._tracker.currentWidget;
     if (current) {
-      return current.parent.parent as TabPanel;
+      return current.parent!.parent as TabPanel;
     }
 
     // Otherwise, fallback on using the top-left tab panel.

--- a/src/ui/dockpanel.ts
+++ b/src/ui/dockpanel.ts
@@ -445,6 +445,8 @@ class DockPanel extends Widget {
       right = rect.right - cr.right - box.borderRight;
       bottom = rect.bottom - cr.bottom - box.borderBottom;
       break;
+    default:
+      throw 'Invalid value for target zone: "' + target.zone + '"';
     }
 
     // Derive the width and height from the other dimensions.

--- a/src/ui/dockpanel.ts
+++ b/src/ui/dockpanel.ts
@@ -139,7 +139,7 @@ class DockPanel extends Widget {
     this._tracker.currentChanged.connect(this._onCurrentChanged, this);
 
     // Add the overlay node to the panel.
-    this.node!.appendChild(this._overlay.node);
+    this.node.appendChild(this._overlay.node);
   }
 
   /**
@@ -314,7 +314,7 @@ class DockPanel extends Widget {
    */
   findDropTarget(clientX: number, clientY: number): DockPanel.IDropTarget {
     // If the position is not over the dock panel, bail.
-    if (!hitTest(this.node!, clientX, clientY)) {
+    if (!hitTest(this.node, clientX, clientY)) {
       return { zone: 'invalid', panel: null };
     }
 
@@ -324,19 +324,19 @@ class DockPanel extends Widget {
     }
 
     // Test for a root zone first.
-    let zone = Private.getRootZone(this.node!, clientX, clientY);
+    let zone = Private.getRootZone(this.node, clientX, clientY);
     if (zone !== 'invalid') {
       return { zone, panel: null };
     }
 
     // Find the panel at the client position.
     let panel = find(this._tabPanels, panel => {
-      return hitTest(panel.node!, clientX, clientY);
+      return hitTest(panel.node, clientX, clientY);
     }) || null;
 
     // Compute the zone for the hit panel, if any.
     if (panel) {
-      zone = Private.getPanelZone(panel.node!, clientX, clientY);
+      zone = Private.getPanelZone(panel.node, clientX, clientY);
     } else {
       zone = 'invalid';
     }
@@ -375,8 +375,8 @@ class DockPanel extends Widget {
     let right: number;
     let bottom: number;
     let cr: ClientRect;
-    let box = boxSizing(this.node!); // TODO cache this?
-    let rect = this.node!.getBoundingClientRect();
+    let box = boxSizing(this.node); // TODO cache this?
+    let rect = this.node.getBoundingClientRect();
 
     // Compute the overlay geometry based on the dock zone.
     switch (target.zone) {
@@ -411,35 +411,35 @@ class DockPanel extends Widget {
       bottom = box.paddingBottom;
       break;
     case 'panel-top':
-      cr = target.panel!.node!.getBoundingClientRect();
+      cr = target.panel!.node.getBoundingClientRect();
       top = cr.top - rect.top - box.borderTop;
       left = cr.left - rect.left - box.borderLeft;
       right = rect.right - cr.right - box.borderRight;
       bottom = rect.bottom - cr.bottom + cr.height / 2 - box.borderBottom;
       break;
     case 'panel-left':
-      cr = target.panel!.node!.getBoundingClientRect();
+      cr = target.panel!.node.getBoundingClientRect();
       top = cr.top - rect.top - box.borderTop;
       left = cr.left - rect.left - box.borderLeft;
       right = rect.right - cr.right + cr.width / 2 - box.borderRight;
       bottom = rect.bottom - cr.bottom - box.borderBottom;
       break;
     case 'panel-right':
-      cr = target.panel!.node!.getBoundingClientRect();
+      cr = target.panel!.node.getBoundingClientRect();
       top = cr.top - rect.top - box.borderTop;
       left = cr.left - rect.left + cr.width / 2 - box.borderLeft;
       right = rect.right - cr.right - box.borderRight;
       bottom = rect.bottom - cr.bottom - box.borderBottom;
       break;
     case 'panel-bottom':
-      cr = target.panel!.node!.getBoundingClientRect();
+      cr = target.panel!.node.getBoundingClientRect();
       top = cr.top - rect.top + cr.height / 2 - box.borderTop;
       left = cr.left - rect.left - box.borderLeft;
       right = rect.right - cr.right - box.borderRight;
       bottom = rect.bottom - cr.bottom - box.borderBottom;
       break;
     case 'panel-center':
-      cr = target.panel!.node!.getBoundingClientRect();
+      cr = target.panel!.node.getBoundingClientRect();
       top = cr.top - rect.top - box.borderTop;
       left = cr.left - rect.left - box.borderLeft;
       right = rect.right - cr.right - box.borderRight;
@@ -497,7 +497,7 @@ class DockPanel extends Widget {
    * A message handler invoked on an `'after-attach'` message.
    */
   protected onAfterAttach(msg: Message): void {
-    let node = this.node!;
+    let node = this.node;
     node.addEventListener('p-dragenter', this);
     node.addEventListener('p-dragleave', this);
     node.addEventListener('p-dragover', this);
@@ -508,7 +508,7 @@ class DockPanel extends Widget {
    * A message handler invoked on a `'before-detach'` message.
    */
   protected onBeforeDetach(msg: Message): void {
-    let node = this.node!;
+    let node = this.node;
     node.removeEventListener('p-dragenter', this);
     node.removeEventListener('p-dragleave', this);
     node.removeEventListener('p-dragover', this);
@@ -521,7 +521,7 @@ class DockPanel extends Widget {
   private _evtDragEnter(event: IDragEvent): void {
     // If the factory mime type is present, mark the event as
     // handled in order to get the rest of the drag events.
-    if (event.mimeData!.hasData(FACTORY_MIME)) {
+    if (event.mimeData.hasData(FACTORY_MIME)) {
       event.preventDefault();
       event.stopPropagation();
     }
@@ -539,7 +539,7 @@ class DockPanel extends Widget {
     let related = event.relatedTarget as HTMLElement;
 
     // Hide the overlay if the drag is leaving the dock panel.
-    if (!related || !this.node!.contains(related)) {
+    if (!related || !this.node.contains(related)) {
       this._overlay.hide(0);
     }
   }
@@ -588,7 +588,7 @@ class DockPanel extends Widget {
     }
 
     // Bail if the factory mime type has invalid data.
-    let factory = event.mimeData!.getData(FACTORY_MIME);
+    let factory = event.mimeData.getData(FACTORY_MIME);
     if (typeof factory !== 'function') {
       event.dropAction = 'none';
       return;
@@ -789,8 +789,8 @@ class DockPanel extends Widget {
   private _createTabPanel(): TabPanel {
     let panel = new TabPanel({ tabsMovable: true });
     panel.addClass(TAB_PANEL_CLASS);
-    panel.tabBar!.tabDetachRequested.connect(this._onTabDetachRequested, this);
-    panel.stackedPanel!.widgetRemoved.connect(this._onWidgetRemoved, this);
+    panel.tabBar.tabDetachRequested.connect(this._onTabDetachRequested, this);
+    panel.stackedPanel.widgetRemoved.connect(this._onWidgetRemoved, this);
     this._tabPanels.pushBack(panel);
     return panel;
   }

--- a/src/ui/dockpanel.ts
+++ b/src/ui/dockpanel.ts
@@ -225,7 +225,7 @@ class DockPanel extends Widget {
    *
    * This is a read-only property.
    */
-  get currentWidget(): Widget {
+  get currentWidget(): Widget | null {
     return this._tracker.currentWidget;
   }
 
@@ -261,7 +261,7 @@ class DockPanel extends Widget {
   addWidget(widget: Widget, options: DockPanel.IAddOptions = {}): void {
     // Setup the option defaults.
     let activate = true;
-    let ref: Widget = null;
+    let ref: Widget | null = null;
     let mode: DockPanel.Mode = 'tab-after';
 
     // Extract the options.
@@ -681,7 +681,7 @@ class DockPanel extends Widget {
    * The target widget should have no parent, and the reference widget
    * should either be null or a widget contained in the dock panel.
    */
-  private _insertWidget(widget: Widget, mode: DockPanel.Mode, ref: Widget): void {
+  private _insertWidget(widget: Widget, mode: DockPanel.Mode, ref: Widget | null): void {
     // Determine whether the insert is before or after the ref.
     let after = (
       mode === 'tab-after' ||
@@ -1042,13 +1042,13 @@ class DockPanel extends Widget {
   }
 
   private _spacing: number;
-  private _drag: Drag = null;
+  private _drag: Drag | null = null;
   private _overlay: DockPanel.IOverlay;
   private _widgets = new Vector<Widget>();
   private _tabPanels = new Vector<TabPanel>();
   private _splitPanels = new Vector<SplitPanel>();
   private _tracker = new FocusTracker<Widget>();
-  private _root: SplitPanel | TabPanel = null;
+  private _root: SplitPanel | TabPanel | null = null;
 }
 
 
@@ -1069,12 +1069,12 @@ namespace DockPanel {
     /**
      * The old value for the `currentWidget`, or `null`.
      */
-    oldValue: Widget;
+    oldValue: Widget | null;
 
     /**
      * The new value for the `currentWidget`, or `null`.
      */
-    newValue: Widget;
+    newValue: Widget | null;
   }
 
   /**
@@ -1272,7 +1272,7 @@ namespace DockPanel {
      *
      * This will be `null` if the dock zone is not a panel zone.
      */
-    panel: TabPanel;
+    panel: TabPanel | null;
   }
 
   /**

--- a/src/ui/dockpanel.ts
+++ b/src/ui/dockpanel.ts
@@ -1116,7 +1116,7 @@ namespace DockPanel {
      *
      * The default is `null`.
      */
-    ref?: Widget;
+    ref?: Widget | null;
 
     /**
      * Whether to activate the new widget.

--- a/src/ui/focustracker.ts
+++ b/src/ui/focustracker.ts
@@ -111,7 +111,7 @@ class FocusTracker<T extends Widget> implements IDisposable {
    *
    * This is a read-only property.
    */
-  get currentWidget(): T {
+  get currentWidget(): T | null {
     return this._currentWidget;
   }
 
@@ -271,7 +271,7 @@ class FocusTracker<T extends Widget> implements IDisposable {
   /**
    * Set the current widget for the tracker.
    */
-  private _setCurrentWidget(widget: T): void {
+  private _setCurrentWidget(widget: T | null): void {
     // Do nothing if there is no change.
     if (this._currentWidget === widget) {
       return;
@@ -307,7 +307,7 @@ class FocusTracker<T extends Widget> implements IDisposable {
   }
 
   private _counter = 0;
-  private _currentWidget: T = null;
+  private _currentWidget: T | null = null;
   private _widgets = new Vector<T>();
   private _numbers = new Map<T, number>();
   private _nodes = new Map<HTMLElement, T>();
@@ -331,11 +331,11 @@ namespace FocusTracker {
     /**
      * The old value for the `currentWidget`, or `null`.
      */
-    oldValue: T;
+    oldValue: T | null;
 
     /**
      * The new value for the `currentWidget`, or `null`.
      */
-    newValue: T;
+    newValue: T | null;
   }
 }

--- a/src/ui/focustracker.ts
+++ b/src/ui/focustracker.ts
@@ -64,7 +64,7 @@ class FocusTracker<T extends Widget> implements IDisposable {
 
     // Remove all event listeners.
     each(this._widgets, widget => {
-      widget.node.removeEventListener('focus', this, true);
+      widget.node!.removeEventListener('focus', this, true);
     });
 
     // Clear the internal data structures.
@@ -182,7 +182,7 @@ class FocusTracker<T extends Widget> implements IDisposable {
     }
 
     // Test whether this widget has focus.
-    let focused = widget.node.contains(document.activeElement);
+    let focused = widget.node!.contains(document.activeElement);
 
     // Setup the initial focus number.
     let n = focused ? this._counter++ : -1;
@@ -190,12 +190,12 @@ class FocusTracker<T extends Widget> implements IDisposable {
     // Add the widget to the internal data structures.
     this._numbers.set(widget, n);
     this._widgets.pushBack(widget);
-    this._nodes.set(widget.node, widget);
+    this._nodes.set(widget.node!, widget);
 
     // Setup the focus event listener. The capturing phase must
     // be used since the 'focus' event doesn't bubble and since
     // firefox doesn't support the 'focusin' event.
-    widget.node.addEventListener('focus', this, true);
+    widget.node!.addEventListener('focus', this, true);
 
     // Connect the disposed signal handler.
     widget.disposed.connect(this._onWidgetDisposed, this);
@@ -226,11 +226,11 @@ class FocusTracker<T extends Widget> implements IDisposable {
     widget.disposed.disconnect(this._onWidgetDisposed, this);
 
     // Remove the focus event listener.
-    widget.node.removeEventListener('focus', this, true);
+    widget.node!.removeEventListener('focus', this, true);
 
     // Remove the widget from the internal data structures.
     this._widgets.remove(widget);
-    this._nodes.delete(widget.node);
+    this._nodes.delete(widget.node!);
     this._numbers.delete(widget);
 
     // If the widget is not the current widget, we're done.

--- a/src/ui/focustracker.ts
+++ b/src/ui/focustracker.ts
@@ -64,7 +64,7 @@ class FocusTracker<T extends Widget> implements IDisposable {
 
     // Remove all event listeners.
     each(this._widgets, widget => {
-      widget.node!.removeEventListener('focus', this, true);
+      widget.node.removeEventListener('focus', this, true);
     });
 
     // Clear the internal data structures.
@@ -182,7 +182,7 @@ class FocusTracker<T extends Widget> implements IDisposable {
     }
 
     // Test whether this widget has focus.
-    let focused = widget.node!.contains(document.activeElement);
+    let focused = widget.node.contains(document.activeElement);
 
     // Setup the initial focus number.
     let n = focused ? this._counter++ : -1;
@@ -190,12 +190,12 @@ class FocusTracker<T extends Widget> implements IDisposable {
     // Add the widget to the internal data structures.
     this._numbers.set(widget, n);
     this._widgets.pushBack(widget);
-    this._nodes.set(widget.node!, widget);
+    this._nodes.set(widget.node, widget);
 
     // Setup the focus event listener. The capturing phase must
     // be used since the 'focus' event doesn't bubble and since
     // firefox doesn't support the 'focusin' event.
-    widget.node!.addEventListener('focus', this, true);
+    widget.node.addEventListener('focus', this, true);
 
     // Connect the disposed signal handler.
     widget.disposed.connect(this._onWidgetDisposed, this);
@@ -226,11 +226,11 @@ class FocusTracker<T extends Widget> implements IDisposable {
     widget.disposed.disconnect(this._onWidgetDisposed, this);
 
     // Remove the focus event listener.
-    widget.node!.removeEventListener('focus', this, true);
+    widget.node.removeEventListener('focus', this, true);
 
     // Remove the widget from the internal data structures.
     this._widgets.remove(widget);
-    this._nodes.delete(widget.node!);
+    this._nodes.delete(widget.node);
     this._numbers.delete(widget);
 
     // If the widget is not the current widget, we're done.

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -139,7 +139,7 @@ class Keymap {
    * sequence of key `bindings`. If custom search behavior is needed,
    * user code may search that sequence manually.
    */
-  findBinding(command: string, args: JSONObject): Keymap.IBinding {
+  findBinding(command: string, args: JSONObject | null): Keymap.IBinding | null {
     let i = findLastIndex(this._bindings, kb => {
       return kb.command === command && deepEqual(kb.args, args);
     });
@@ -240,7 +240,7 @@ class Keymap {
     // can be dispatched immediately. The pending state is cleared so
     // the next key press starts from the default state.
     if (!partial) {
-      this._execute(exact);
+      this._execute(exact!);
       this._clearPendingState();
       return;
     }
@@ -335,7 +335,7 @@ class Keymap {
   private _layout: IKeyboardLayout;
   private _commands: CommandRegistry;
   private _events: KeyboardEvent[] = [];
-  private _exact: Keymap.IBinding = null;
+  private _exact: Keymap.IBinding | null = null;
   private _bindings = new Vector<Keymap.IBinding>();
 }
 
@@ -414,7 +414,7 @@ namespace Keymap {
     /**
      * The arguments for the command, if necessary.
      */
-    args?: JSONObject;
+    args?: JSONObject | null;
 
     /**
      * The key sequence to use when running on Windows.
@@ -464,7 +464,7 @@ namespace Keymap {
     /**
      * The arguments for the command.
      */
-    args: JSONObject;
+    args: JSONObject | null;
   }
 
   /**
@@ -709,7 +709,7 @@ namespace Private {
     /**
      * The best binding which exactly matches the key sequence.
      */
-    exact: Keymap.IBinding;
+    exact: Keymap.IBinding | null;
 
     /**
      * Whether there are bindings which partially match the sequence.
@@ -729,7 +729,7 @@ namespace Private {
     let partial = false;
 
     // The current best exact match.
-    let exact: Keymap.IBinding = null;
+    let exact: Keymap.IBinding | null = null;
 
     // The match distance for the exact match.
     let distance = Infinity;
@@ -829,14 +829,14 @@ namespace Private {
     /**
      * The arguments for the command.
      */
-    get args(): JSONObject {
+    get args(): JSONObject | null {
       return this._args;
     }
 
     private _keys: string[];
     private _selector: string;
     private _command: string;
-    private _args: JSONObject;
+    private _args: JSONObject | null;
   }
 
   /**

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -93,7 +93,7 @@ class Keymap {
    * #### Notes
    * The default is a US English layout.
    */
-  get layout(): IKeyboardLayout {
+  get layout(): IKeyboardLayout | null {
     return this._layout;
   }
 
@@ -104,7 +104,7 @@ class Keymap {
    * A keymap requires a keyboard layout, so setting this value to
    * `null` will revert the layout to the default US English layout.
    */
-  set layout(value: IKeyboardLayout) {
+  set layout(value: IKeyboardLayout | null) {
     let oldValue = this._layout;
     let newValue = value || EN_US;
     if (oldValue === newValue) {

--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -162,9 +162,10 @@ class Menu extends Widget {
     this.close();
     this._items.clear();
     this._nodes.clear();
-    this._keymap = null;
-    this._commands = null;
-    this._renderer = null;
+    // Do not type check these on disposed objects:
+    this._keymap = null!;
+    this._commands = null!;
+    this._renderer = null!;
     super.dispose();
   }
 
@@ -257,7 +258,7 @@ class Menu extends Widget {
    * This is a read-only property.
    */
   get contentNode(): HTMLUListElement {
-    return this.node!.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
+    return this.node.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
   }
 
   /**
@@ -266,7 +267,7 @@ class Menu extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get commands(): CommandRegistry | null {
+  get commands(): CommandRegistry {
     return this._commands;
   }
 
@@ -276,7 +277,7 @@ class Menu extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get keymap(): Keymap | null {
+  get keymap(): Keymap {
     return this._keymap;
   }
 
@@ -286,7 +287,7 @@ class Menu extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get renderer(): Menu.IRenderer | null {
+  get renderer(): Menu.IRenderer {
     return this._renderer;
   }
 
@@ -454,8 +455,8 @@ class Menu extends Widget {
 
     // Execute the command for the item.
     let { command, args } = item;
-    if (this._commands!.isEnabled(command, args)) {
-      this._commands!.execute(command, args);
+    if (this._commands.isEnabled(command, args)) {
+      this._commands.execute(command, args);
     } else {
       // TODO - is this the right logging here?
       console.log(`Command '${command}' is disabled.`);
@@ -498,10 +499,10 @@ class Menu extends Widget {
     let i = Math.max(0, Math.min(Math.floor(index), this._items.length));
 
     // Create the item for the options.
-    let item = Private.createItem(this._commands!, this._keymap!, options);
+    let item = Private.createItem(this._commands, this._keymap, options);
 
     // Create the node for the item. It will be initialized on open.
-    let node = this._renderer!.createItemNode();
+    let node = this._renderer.createItemNode();
 
     // Insert the item and node into the vectors.
     this._items.insert(i, item);
@@ -659,13 +660,12 @@ class Menu extends Widget {
    * A message handler invoked on an `'after-attach'` message.
    */
   protected onAfterAttach(msg: Message): void {
-    let node = this.node!;
-    node.addEventListener('keydown', this);
-    node.addEventListener('mouseup', this);
-    node.addEventListener('mousemove', this);
-    node.addEventListener('mouseenter', this);
-    node.addEventListener('mouseleave', this);
-    node.addEventListener('contextmenu', this);
+    this.node.addEventListener('keydown', this);
+    this.node.addEventListener('mouseup', this);
+    this.node.addEventListener('mousemove', this);
+    this.node.addEventListener('mouseenter', this);
+    this.node.addEventListener('mouseleave', this);
+    this.node.addEventListener('contextmenu', this);
     document.addEventListener('mousedown', this, true);
   }
 
@@ -673,13 +673,12 @@ class Menu extends Widget {
    * A message handler invoked on a `'before-detach'` message.
    */
   protected onBeforeDetach(msg: Message): void {
-    let node = this.node!;
-    node.removeEventListener('keydown', this);
-    node.removeEventListener('mouseup', this);
-    node.removeEventListener('mousemove', this);
-    node.removeEventListener('mouseenter', this);
-    node.removeEventListener('mouseleave', this);
-    node.removeEventListener('contextmenu', this);
+    this.node.removeEventListener('keydown', this);
+    this.node.removeEventListener('mouseup', this);
+    this.node.removeEventListener('mousemove', this);
+    this.node.removeEventListener('mouseenter', this);
+    this.node.removeEventListener('mouseleave', this);
+    this.node.removeEventListener('contextmenu', this);
     document.removeEventListener('mousedown', this, true);
   }
 
@@ -687,14 +686,14 @@ class Menu extends Widget {
    * A message handler invoked on an `'activate-request'` message.
    */
   protected onActivateRequest(msg: Message): void {
-    if (this.isAttached) this.node!.focus();
+    if (this.isAttached) this.node.focus();
   }
 
   /**
    * A message handler invoked on a `'deactivate-request'` message.
    */
   protected onDeactivateRequest(msg: Message): void {
-    if (this.isAttached) this.node!.blur();
+    if (this.isAttached) this.node.blur();
   }
 
   /**
@@ -710,7 +709,7 @@ class Menu extends Widget {
     // Fetch common variables.
     let items = this._items;
     let nodes = this._nodes;
-    let renderer = this._renderer!;
+    let renderer = this._renderer;
 
     // Update the state of the item nodes.
     for (let i = 0, n = items.length; i < n; ++i) {
@@ -828,7 +827,7 @@ class Menu extends Widget {
     // The following code activates an item by mnemonic.
 
     // Get the pressed key character for the current layout.
-    let key = this._keymap!.layout.keyForKeydownEvent(event);
+    let key = this._keymap.layout!.keyForKeydownEvent(event);
 
     // Bail if the key is not valid for the current layout.
     if (!key) {
@@ -984,7 +983,7 @@ class Menu extends Widget {
     }
 
     // If the mouse is over the child menu, cancel the close timer.
-    if (hitTest(this._childMenu.node!, event.clientX, event.clientY)) {
+    if (hitTest(this._childMenu.node, event.clientX, event.clientY)) {
       this._cancelCloseTimer();
       return;
     }
@@ -1116,15 +1115,15 @@ class Menu extends Widget {
     }
   }
 
-  private _keymap: Keymap | null;
+  private _keymap: Keymap;
   private _childIndex = -1;
   private _openTimerID = 0;
   private _closeTimerID = 0;
   private _activeIndex = -1;
   private _childMenu: Menu | null = null;
   private _parentMenu: Menu | null = null;
-  private _renderer: Menu.IRenderer | null;
-  private _commands: CommandRegistry | null;
+  private _renderer: Menu.IRenderer;
+  private _commands: CommandRegistry;
   private _items = new Vector<Menu.IItem>();
   private _nodes = new Vector<HTMLLIElement>();
 }
@@ -1200,7 +1199,7 @@ namespace Menu {
      *
      * The default value is `null`.
      */
-    menu?: Menu | null;
+    menu?: Menu;
   }
 
   /**
@@ -1513,7 +1512,7 @@ namespace Private {
   export
   function hitTestMenus(menu: Menu | null, x: number, y: number): boolean {
     for (; menu; menu = menu.childMenu) {
-      if (hitTest(menu.node!, x, y)) return true;
+      if (hitTest(menu.node, x, y)) return true;
     }
     return false;
   }
@@ -1585,7 +1584,7 @@ namespace Private {
     let maxHeight = ch - (forceY ? y : 0);
 
     // Fetch common variables.
-    let node = menu.node!;
+    let node = menu.node;
     let style = node.style;
 
     // Clear the menu geometry and prepare it for measuring.
@@ -1647,7 +1646,7 @@ namespace Private {
     let maxHeight = ch;
 
     // Fetch common variables.
-    let node = menu.node!;
+    let node = menu.node;
     let style = node.style;
 
     // Clear the menu geometry and prepare it for measuring.
@@ -1670,7 +1669,7 @@ namespace Private {
     let { width, height } = node.getBoundingClientRect();
 
     // Compute the box sizing for the menu.
-    let box = boxSizing(node);
+    let box = boxSizing(menu.node);
 
     // Get the bounding rect for the target item node.
     let itemRect = itemNode.getBoundingClientRect();

--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -1199,7 +1199,7 @@ namespace Menu {
      *
      * The default value is `null`.
      */
-    menu?: Menu;
+    menu?: Menu | null;
   }
 
   /**

--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -306,7 +306,7 @@ class Menu extends Widget {
    * #### Notes
    * This will be `null` if no menu item is active.
    */
-  get activeItem(): Menu.IItem {
+  get activeItem(): Menu.IItem | null {
     let i = this._activeIndex;
     return i !== -1 ? this._items.at(i) : null;
   }
@@ -317,7 +317,7 @@ class Menu extends Widget {
    * #### Notes
    * If the item cannot be activated, the item will be set to `null`.
    */
-  set activeItem(value: Menu.IItem) {
+  set activeItem(value: Menu.IItem | null) {
     this.activeIndex = indexOf(this._items, value);
   }
 
@@ -539,7 +539,7 @@ class Menu extends Widget {
    * @returns The item occupying the index, or `null` if the index
    *   is out of range.
    */
-  removeItemAt(index: number): Menu.IItem {
+  removeItemAt(index: number): Menu.IItem | null {
     // Bail if the index is out of range.
     let i = Math.floor(index);
     if (i < 0 || i >= this._items.length) {
@@ -555,8 +555,8 @@ class Menu extends Widget {
     this.activeIndex = -1;
 
     // Remove the node and items from the vectors.
-    let node = this._nodes.removeAt(i);
-    let item = this._items.removeAt(i);
+    let node = this._nodes.removeAt(i)!;
+    let item = this._items.removeAt(i)!;
 
     // Remove the node from the content node.
     this.contentNode.removeChild(node);
@@ -1114,15 +1114,15 @@ class Menu extends Widget {
     }
   }
 
-  private _keymap: Keymap;
+  private _keymap: Keymap | null;
   private _childIndex = -1;
   private _openTimerID = 0;
   private _closeTimerID = 0;
   private _activeIndex = -1;
-  private _childMenu: Menu = null;
-  private _parentMenu: Menu = null;
-  private _renderer: Menu.IRenderer;
-  private _commands: CommandRegistry;
+  private _childMenu: Menu | null = null;
+  private _parentMenu: Menu | null = null;
+  private _renderer: Menu.IRenderer | null;
+  private _commands: CommandRegistry | null;
   private _items = new Vector<Menu.IItem>();
   private _nodes = new Vector<HTMLLIElement>();
 }
@@ -1191,7 +1191,7 @@ namespace Menu {
      *
      * The default value is `null`.
      */
-    args?: JSONObject;
+    args?: JSONObject | null;
 
     /**
      * The menu for a `'submenu'` type item.
@@ -1222,7 +1222,7 @@ namespace Menu {
     /**
      * The arguments for the command.
      */
-    args: JSONObject;
+    args: JSONObject | null;
 
     /**
      * The menu for a `'submenu'` type item.
@@ -1467,7 +1467,7 @@ namespace Menu {
      *
      * @returns The formatted shortcut text for display.
      */
-    formatShortcut(binding: Keymap.IBinding): string {
+    formatShortcut(binding: Keymap.IBinding | null): string {
       return binding ? binding.keys.map(Keymap.formatKeystroke).join(' ') : '';
     }
   }
@@ -1509,7 +1509,7 @@ namespace Private {
    * Hit test a menu hierarchy starting at the given root.
    */
   export
-  function hitTestMenus(menu: Menu, x: number, y: number): boolean {
+  function hitTestMenus(menu: Menu | null, x: number, y: number): boolean {
     for (; menu; menu = menu.childMenu) {
       if (hitTest(menu.node, x, y)) return true;
     }
@@ -1730,7 +1730,7 @@ namespace Private {
     /**
      * The arguments for the command.
      */
-    get args(): JSONObject {
+    get args(): JSONObject | null {
       return this._args;
     }
 
@@ -1856,7 +1856,7 @@ namespace Private {
     private _keymap: Keymap;
     private _type: Menu.ItemType;
     private _command: string;
-    private _args: JSONObject;
-    private _menu: Menu;
+    private _args: JSONObject | null;
+    private _menu: Menu | null;
   }
 }

--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -202,7 +202,7 @@ class Menu extends Widget {
    *
    * This is a read-only property.
    */
-  get parentMenu(): Menu {
+  get parentMenu(): Menu | null {
     return this._parentMenu;
   }
 
@@ -214,7 +214,7 @@ class Menu extends Widget {
    *
    * This is a read-only property.
    */
-  get childMenu(): Menu {
+  get childMenu(): Menu | null {
     return this._childMenu;
   }
 
@@ -266,7 +266,7 @@ class Menu extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get commands(): CommandRegistry {
+  get commands(): CommandRegistry | null {
     return this._commands;
   }
 
@@ -276,7 +276,7 @@ class Menu extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get keymap(): Keymap {
+  get keymap(): Keymap | null {
     return this._keymap;
   }
 
@@ -286,7 +286,7 @@ class Menu extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get renderer(): Menu.IRenderer {
+  get renderer(): Menu.IRenderer | null {
     return this._renderer;
   }
 
@@ -1198,7 +1198,7 @@ namespace Menu {
      *
      * The default value is `null`.
      */
-    menu?: Menu;
+    menu?: Menu | null;
   }
 
   /**
@@ -1227,7 +1227,7 @@ namespace Menu {
     /**
      * The menu for a `'submenu'` type item.
      */
-    menu: Menu;
+    menu: Menu | null;
 
     /**
      * The display label for the menu item.
@@ -1272,7 +1272,7 @@ namespace Menu {
     /**
      * The key binding for the menu item.
      */
-    keyBinding: Keymap.IBinding;
+    keyBinding: Keymap.IBinding | null;
   }
 
   /**
@@ -1737,7 +1737,7 @@ namespace Private {
     /**
      * The menu for a `'submenu'` type item.
      */
-    get menu(): Menu {
+    get menu(): Menu | null {
       return this._menu;
     }
 
@@ -1845,7 +1845,7 @@ namespace Private {
     /**
      * The key binding for the menu item.
      */
-    get keyBinding(): Keymap.IBinding {
+    get keyBinding(): Keymap.IBinding | null {
       if (this._type === 'command') {
         return this._keymap.findBinding(this._command, this._args);
       }

--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -257,7 +257,7 @@ class Menu extends Widget {
    * This is a read-only property.
    */
   get contentNode(): HTMLUListElement {
-    return this.node.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
+    return this.node!.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
   }
 
   /**
@@ -454,8 +454,8 @@ class Menu extends Widget {
 
     // Execute the command for the item.
     let { command, args } = item;
-    if (this._commands.isEnabled(command, args)) {
-      this._commands.execute(command, args);
+    if (this._commands!.isEnabled(command, args)) {
+      this._commands!.execute(command, args);
     } else {
       // TODO - is this the right logging here?
       console.log(`Command '${command}' is disabled.`);
@@ -498,10 +498,10 @@ class Menu extends Widget {
     let i = Math.max(0, Math.min(Math.floor(index), this._items.length));
 
     // Create the item for the options.
-    let item = Private.createItem(this._commands, this._keymap, options);
+    let item = Private.createItem(this._commands!, this._keymap!, options);
 
     // Create the node for the item. It will be initialized on open.
-    let node = this._renderer.createItemNode();
+    let node = this._renderer!.createItemNode();
 
     // Insert the item and node into the vectors.
     this._items.insert(i, item);
@@ -659,12 +659,13 @@ class Menu extends Widget {
    * A message handler invoked on an `'after-attach'` message.
    */
   protected onAfterAttach(msg: Message): void {
-    this.node.addEventListener('keydown', this);
-    this.node.addEventListener('mouseup', this);
-    this.node.addEventListener('mousemove', this);
-    this.node.addEventListener('mouseenter', this);
-    this.node.addEventListener('mouseleave', this);
-    this.node.addEventListener('contextmenu', this);
+    let node = this.node!;
+    node.addEventListener('keydown', this);
+    node.addEventListener('mouseup', this);
+    node.addEventListener('mousemove', this);
+    node.addEventListener('mouseenter', this);
+    node.addEventListener('mouseleave', this);
+    node.addEventListener('contextmenu', this);
     document.addEventListener('mousedown', this, true);
   }
 
@@ -672,12 +673,13 @@ class Menu extends Widget {
    * A message handler invoked on a `'before-detach'` message.
    */
   protected onBeforeDetach(msg: Message): void {
-    this.node.removeEventListener('keydown', this);
-    this.node.removeEventListener('mouseup', this);
-    this.node.removeEventListener('mousemove', this);
-    this.node.removeEventListener('mouseenter', this);
-    this.node.removeEventListener('mouseleave', this);
-    this.node.removeEventListener('contextmenu', this);
+    let node = this.node!;
+    node.removeEventListener('keydown', this);
+    node.removeEventListener('mouseup', this);
+    node.removeEventListener('mousemove', this);
+    node.removeEventListener('mouseenter', this);
+    node.removeEventListener('mouseleave', this);
+    node.removeEventListener('contextmenu', this);
     document.removeEventListener('mousedown', this, true);
   }
 
@@ -685,14 +687,14 @@ class Menu extends Widget {
    * A message handler invoked on an `'activate-request'` message.
    */
   protected onActivateRequest(msg: Message): void {
-    if (this.isAttached) this.node.focus();
+    if (this.isAttached) this.node!.focus();
   }
 
   /**
    * A message handler invoked on a `'deactivate-request'` message.
    */
   protected onDeactivateRequest(msg: Message): void {
-    if (this.isAttached) this.node.blur();
+    if (this.isAttached) this.node!.blur();
   }
 
   /**
@@ -708,7 +710,7 @@ class Menu extends Widget {
     // Fetch common variables.
     let items = this._items;
     let nodes = this._nodes;
-    let renderer = this._renderer;
+    let renderer = this._renderer!;
 
     // Update the state of the item nodes.
     for (let i = 0, n = items.length; i < n; ++i) {
@@ -826,7 +828,7 @@ class Menu extends Widget {
     // The following code activates an item by mnemonic.
 
     // Get the pressed key character for the current layout.
-    let key = this._keymap.layout.keyForKeydownEvent(event);
+    let key = this._keymap!.layout.keyForKeydownEvent(event);
 
     // Bail if the key is not valid for the current layout.
     if (!key) {
@@ -982,7 +984,7 @@ class Menu extends Widget {
     }
 
     // If the mouse is over the child menu, cancel the close timer.
-    if (hitTest(this._childMenu.node, event.clientX, event.clientY)) {
+    if (hitTest(this._childMenu.node!, event.clientX, event.clientY)) {
       this._cancelCloseTimer();
       return;
     }
@@ -1511,7 +1513,7 @@ namespace Private {
   export
   function hitTestMenus(menu: Menu | null, x: number, y: number): boolean {
     for (; menu; menu = menu.childMenu) {
-      if (hitTest(menu.node, x, y)) return true;
+      if (hitTest(menu.node!, x, y)) return true;
     }
     return false;
   }
@@ -1583,7 +1585,7 @@ namespace Private {
     let maxHeight = ch - (forceY ? y : 0);
 
     // Fetch common variables.
-    let node = menu.node;
+    let node = menu.node!;
     let style = node.style;
 
     // Clear the menu geometry and prepare it for measuring.
@@ -1645,7 +1647,7 @@ namespace Private {
     let maxHeight = ch;
 
     // Fetch common variables.
-    let node = menu.node;
+    let node = menu.node!;
     let style = node.style;
 
     // Clear the menu geometry and prepare it for measuring.
@@ -1668,7 +1670,7 @@ namespace Private {
     let { width, height } = node.getBoundingClientRect();
 
     // Compute the box sizing for the menu.
-    let box = boxSizing(menu.node);
+    let box = boxSizing(node);
 
     // Get the bounding rect for the target item node.
     let itemRect = itemNode.getBoundingClientRect();

--- a/src/ui/menubar.ts
+++ b/src/ui/menubar.ts
@@ -141,7 +141,7 @@ class MenuBar extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get keymap(): Keymap {
+  get keymap(): Keymap | null {
     return this._keymap;
   }
 
@@ -151,7 +151,7 @@ class MenuBar extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get renderer(): MenuBar.IRenderer {
+  get renderer(): MenuBar.IRenderer | null {
     return this._renderer;
   }
 
@@ -173,7 +173,7 @@ class MenuBar extends Widget {
    *
    * This is a read-only property.
    */
-  get childMenu(): Menu {
+  get childMenu(): Menu | null {
     return this._childMenu;
   }
 

--- a/src/ui/menubar.ts
+++ b/src/ui/menubar.ts
@@ -558,7 +558,7 @@ class MenuBar extends Widget {
     // The following code activates an item by mnemonic.
 
     // Get the pressed key character for the current layout.
-    let key = this._keymap!.layout.keyForKeydownEvent(event);
+    let key = this._keymap!.layout!.keyForKeydownEvent(event);
 
     // Bail if the key is not valid for the current layout.
     if (!key) {

--- a/src/ui/menubar.ts
+++ b/src/ui/menubar.ts
@@ -132,7 +132,7 @@ class MenuBar extends Widget {
    * This is a read-only property.
    */
   get contentNode(): HTMLUListElement {
-    return this.node.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
+    return this.node!.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
   }
 
   /**
@@ -301,8 +301,8 @@ class MenuBar extends Widget {
     // If the menu is not in the vector, insert it.
     if (i === -1) {
       // Create the new item node for the menu.
-      let node = this._renderer.createItemNode();
-      this._renderer.updateItemNode(node, menu.title);
+      let node = this._renderer!.createItemNode();
+      this._renderer!.updateItemNode(node, menu.title);
 
       // Insert the node and menu into the vectors.
       this._nodes.insert(j, node);
@@ -459,22 +459,24 @@ class MenuBar extends Widget {
    * A message handler invoked on an `'after-attach'` message.
    */
   protected onAfterAttach(msg: Message): void {
-    this.node.addEventListener('keydown', this);
-    this.node.addEventListener('mousedown', this);
-    this.node.addEventListener('mousemove', this);
-    this.node.addEventListener('mouseleave', this);
-    this.node.addEventListener('contextmenu', this);
+    let node = this.node!;
+    node.addEventListener('keydown', this);
+    node.addEventListener('mousedown', this);
+    node.addEventListener('mousemove', this);
+    node.addEventListener('mouseleave', this);
+    node.addEventListener('contextmenu', this);
   }
 
   /**
    * A message handler invoked on a `'before-detach'` message.
    */
   protected onBeforeDetach(msg: Message): void {
-    this.node.removeEventListener('keydown', this);
-    this.node.removeEventListener('mousedown', this);
-    this.node.removeEventListener('mousemove', this);
-    this.node.removeEventListener('mouseleave', this);
-    this.node.removeEventListener('contextmenu', this);
+    let node = this.node!;
+    node.removeEventListener('keydown', this);
+    node.removeEventListener('mousedown', this);
+    node.removeEventListener('mousemove', this);
+    node.removeEventListener('mouseleave', this);
+    node.removeEventListener('contextmenu', this);
     this._closeChildMenu();
   }
 
@@ -482,14 +484,14 @@ class MenuBar extends Widget {
    * A message handler invoked on an `'activate-request'` message.
    */
   protected onActivateRequest(msg: Message): void {
-    if (this.isAttached) this.node.focus();
+    if (this.isAttached) this.node!.focus();
   }
 
   /**
    * A message handler invoked on a `'deactivate-request'` message.
    */
   protected onDeactivateRequest(msg: Message): void {
-    if (this.isAttached) this.node.blur();
+    if (this.isAttached) this.node!.blur();
   }
 
   /**
@@ -499,7 +501,7 @@ class MenuBar extends Widget {
     // Fetch common variables.
     let menus = this._menus;
     let nodes = this._nodes;
-    let renderer = this._renderer;
+    let renderer = this._renderer!;
 
     // Update the state of the item nodes.
     for (let i = 0, n = menus.length; i < n; ++i) {
@@ -556,7 +558,7 @@ class MenuBar extends Widget {
     // The following code activates an item by mnemonic.
 
     // Get the pressed key character for the current layout.
-    let key = this._keymap.layout.keyForKeydownEvent(event);
+    let key = this._keymap!.layout.keyForKeydownEvent(event);
 
     // Bail if the key is not valid for the current layout.
     if (!key) {
@@ -623,7 +625,7 @@ class MenuBar extends Widget {
     // when the document listener is installed for an active menu bar.
     let x = event.clientX;
     let y = event.clientY;
-    if (!hitTest(this.node, x, y)) {
+    if (!hitTest(this.node!, x, y)) {
       return;
     }
 

--- a/src/ui/menubar.ts
+++ b/src/ui/menubar.ts
@@ -183,7 +183,7 @@ class MenuBar extends Widget {
    * #### Notes
    * This will be `null` if no menu is active.
    */
-  get activeMenu(): Menu {
+  get activeMenu(): Menu | null {
     let i = this._activeIndex;
     return i !== -1 ? this._menus.at(i): null;
   }
@@ -194,7 +194,7 @@ class MenuBar extends Widget {
    * #### Notes
    * If the menu does not exist, the menu will be set to `null`.
    */
-  set activeMenu(value: Menu) {
+  set activeMenu(value: Menu | null) {
     this.activeIndex = indexOf(this._menus, value);
   }
 
@@ -367,7 +367,7 @@ class MenuBar extends Widget {
    * @returns The menu occupying the index, or `null` if the index
    *   is out of range.
    */
-  removeMenuAt(index: number): Menu {
+  removeMenuAt(index: number): Menu | null {
     // Bail if the index is out of range.
     let i = Math.floor(index);
     if (i < 0 || i >= this._menus.length) {
@@ -378,8 +378,8 @@ class MenuBar extends Widget {
     this._closeChildMenu();
 
     // Remove the node and menu from the vectors.
-    let node = this._nodes.removeAt(i);
-    let menu = this._menus.removeAt(i);
+    let node = this._nodes.removeAt(i)!;
+    let menu = this._menus.removeAt(i)!;
 
     // Disconnect from the menu signals.
     menu.aboutToClose.disconnect(this._onMenuAboutToClose, this);
@@ -820,12 +820,12 @@ class MenuBar extends Widget {
     this.update();
   }
 
-  private _keymap: Keymap;
+  private _keymap: Keymap | null;
   private _activeIndex = -1;
-  private _childMenu: Menu = null;
+  private _childMenu: Menu | null = null;
   private _menus = new Vector<Menu>();
   private _nodes = new Vector<HTMLLIElement>();
-  private _renderer: MenuBar.IRenderer;
+  private _renderer: MenuBar.IRenderer | null;
 }
 
 

--- a/src/ui/menubar.ts
+++ b/src/ui/menubar.ts
@@ -116,8 +116,9 @@ class MenuBar extends Widget {
     this._closeChildMenu();
     this._menus.clear();
     this._nodes.clear();
-    this._keymap = null;
-    this._renderer = null;
+    // Do not ype check these for disposed objects
+    this._keymap = null!;
+    this._renderer = null!;
     super.dispose();
   }
 
@@ -132,7 +133,7 @@ class MenuBar extends Widget {
    * This is a read-only property.
    */
   get contentNode(): HTMLUListElement {
-    return this.node!.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
+    return this.node.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
   }
 
   /**
@@ -141,7 +142,7 @@ class MenuBar extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get keymap(): Keymap | null {
+  get keymap(): Keymap {
     return this._keymap;
   }
 
@@ -151,7 +152,7 @@ class MenuBar extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get renderer(): MenuBar.IRenderer | null {
+  get renderer(): MenuBar.IRenderer {
     return this._renderer;
   }
 
@@ -301,8 +302,8 @@ class MenuBar extends Widget {
     // If the menu is not in the vector, insert it.
     if (i === -1) {
       // Create the new item node for the menu.
-      let node = this._renderer!.createItemNode();
-      this._renderer!.updateItemNode(node, menu.title);
+      let node = this._renderer.createItemNode();
+      this._renderer.updateItemNode(node, menu.title);
 
       // Insert the node and menu into the vectors.
       this._nodes.insert(j, node);
@@ -459,24 +460,22 @@ class MenuBar extends Widget {
    * A message handler invoked on an `'after-attach'` message.
    */
   protected onAfterAttach(msg: Message): void {
-    let node = this.node!;
-    node.addEventListener('keydown', this);
-    node.addEventListener('mousedown', this);
-    node.addEventListener('mousemove', this);
-    node.addEventListener('mouseleave', this);
-    node.addEventListener('contextmenu', this);
+    this.node.addEventListener('keydown', this);
+    this.node.addEventListener('mousedown', this);
+    this.node.addEventListener('mousemove', this);
+    this.node.addEventListener('mouseleave', this);
+    this.node.addEventListener('contextmenu', this);
   }
 
   /**
    * A message handler invoked on a `'before-detach'` message.
    */
   protected onBeforeDetach(msg: Message): void {
-    let node = this.node!;
-    node.removeEventListener('keydown', this);
-    node.removeEventListener('mousedown', this);
-    node.removeEventListener('mousemove', this);
-    node.removeEventListener('mouseleave', this);
-    node.removeEventListener('contextmenu', this);
+    this.node.removeEventListener('keydown', this);
+    this.node.removeEventListener('mousedown', this);
+    this.node.removeEventListener('mousemove', this);
+    this.node.removeEventListener('mouseleave', this);
+    this.node.removeEventListener('contextmenu', this);
     this._closeChildMenu();
   }
 
@@ -484,14 +483,14 @@ class MenuBar extends Widget {
    * A message handler invoked on an `'activate-request'` message.
    */
   protected onActivateRequest(msg: Message): void {
-    if (this.isAttached) this.node!.focus();
+    if (this.isAttached) this.node.focus();
   }
 
   /**
    * A message handler invoked on a `'deactivate-request'` message.
    */
   protected onDeactivateRequest(msg: Message): void {
-    if (this.isAttached) this.node!.blur();
+    if (this.isAttached) this.node.blur();
   }
 
   /**
@@ -501,7 +500,7 @@ class MenuBar extends Widget {
     // Fetch common variables.
     let menus = this._menus;
     let nodes = this._nodes;
-    let renderer = this._renderer!;
+    let renderer = this._renderer;
 
     // Update the state of the item nodes.
     for (let i = 0, n = menus.length; i < n; ++i) {
@@ -558,7 +557,8 @@ class MenuBar extends Widget {
     // The following code activates an item by mnemonic.
 
     // Get the pressed key character for the current layout.
-    let key = this._keymap!.layout!.keyForKeydownEvent(event);
+
+    let key = this._keymap.layout!.keyForKeydownEvent(event);
 
     // Bail if the key is not valid for the current layout.
     if (!key) {
@@ -625,7 +625,7 @@ class MenuBar extends Widget {
     // when the document listener is installed for an active menu bar.
     let x = event.clientX;
     let y = event.clientY;
-    if (!hitTest(this.node!, x, y)) {
+    if (!hitTest(this.node, x, y)) {
       return;
     }
 
@@ -822,12 +822,12 @@ class MenuBar extends Widget {
     this.update();
   }
 
-  private _keymap: Keymap | null;
+  private _keymap: Keymap;
   private _activeIndex = -1;
   private _childMenu: Menu | null = null;
   private _menus = new Vector<Menu>();
   private _nodes = new Vector<HTMLLIElement>();
-  private _renderer: MenuBar.IRenderer | null;
+  private _renderer: MenuBar.IRenderer;
 }
 
 

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -143,7 +143,7 @@ class PanelLayout extends Layout {
    */
   dispose(): void {
     while (this._widgets.length > 0) {
-      this._widgets.popBack().dispose();
+      this._widgets.popBack()!.dispose();
     }
     super.dispose();
   }
@@ -267,7 +267,7 @@ class PanelLayout extends Layout {
    *
    * This method does *not* modify the widget's `parent`.
    */
-  removeWidgetAt(index: number): Widget {
+  removeWidgetAt(index: number): Widget | null {
     // Bail if the index is out of range.
     let i = Math.floor(index);
     if (i < 0 || i >= this._widgets.length) {
@@ -275,7 +275,7 @@ class PanelLayout extends Layout {
     }
 
     // Remove the widget from the vector.
-    let widget = this._widgets.removeAt(i);
+    let widget = this._widgets.removeAt(i)!;
 
     // If the layout is parented, detach the widget from the DOM.
     if (this.parent) this.detachWidget(i, widget);

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -306,13 +306,13 @@ class PanelLayout extends Layout {
    */
   protected attachWidget(index: number, widget: Widget): void {
     // Look up the next sibling reference node.
-    let ref = this.parent.node.children[index];
+    let ref = this.parent!.node!.children[index];
 
     // Insert the widget's node before the sibling.
-    this.parent.node.insertBefore(widget.node, ref);
+    this.parent!.node!.insertBefore(widget.node!, ref);
 
     // Send an `'after-attach'` message if the parent is attached.
-    if (this.parent.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
+    if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
   }
 
   /**
@@ -340,19 +340,21 @@ class PanelLayout extends Layout {
    */
   protected moveWidget(fromIndex: number, toIndex: number, widget: Widget): void {
     // Send a `'before-detach'` message if the parent is attached.
-    if (this.parent.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
+    if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
+
+    let parentNode = this.parent!.node!;
 
     // Remove the widget's node from the parent.
-    this.parent.node.removeChild(widget.node);
+    parentNode.removeChild(widget.node!);
 
     // Look up the next sibling reference node.
-    let ref = this.parent.node.children[toIndex];
+    let ref = parentNode.children[toIndex];
 
     // Insert the widget's node before the sibling.
-    this.parent.node.insertBefore(widget.node, ref);
+    parentNode.insertBefore(widget.node!, ref);
 
     // Send an `'after-attach'` message if the parent is attached.
-    if (this.parent.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
+    if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
   }
 
   /**
@@ -377,10 +379,10 @@ class PanelLayout extends Layout {
    */
   protected detachWidget(index: number, widget: Widget): void {
     // Send a `'before-detach'` message if the parent is attached.
-    if (this.parent.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
+    if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
 
     // Remove the widget's node from the parent.
-    this.parent.node.removeChild(widget.node);
+    this.parent!.node!.removeChild(widget.node!);
   }
 
   /**

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -306,10 +306,10 @@ class PanelLayout extends Layout {
    */
   protected attachWidget(index: number, widget: Widget): void {
     // Look up the next sibling reference node.
-    let ref = this.parent!.node!.children[index];
+    let ref = this.parent!.node.children[index];
 
     // Insert the widget's node before the sibling.
-    this.parent!.node!.insertBefore(widget.node!, ref);
+    this.parent!.node.insertBefore(widget.node, ref);
 
     // Send an `'after-attach'` message if the parent is attached.
     if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
@@ -342,16 +342,14 @@ class PanelLayout extends Layout {
     // Send a `'before-detach'` message if the parent is attached.
     if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
 
-    let parentNode = this.parent!.node!;
-
     // Remove the widget's node from the parent.
-    parentNode.removeChild(widget.node!);
+    this.parent!.node.removeChild(widget.node);
 
     // Look up the next sibling reference node.
-    let ref = parentNode.children[toIndex];
+    let ref = this.parent!.node.children[toIndex];
 
     // Insert the widget's node before the sibling.
-    parentNode.insertBefore(widget.node!, ref);
+    this.parent!.node.insertBefore(widget.node, ref);
 
     // Send an `'after-attach'` message if the parent is attached.
     if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
@@ -382,7 +380,7 @@ class PanelLayout extends Layout {
     if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
 
     // Remove the widget's node from the parent.
-    this.parent!.node!.removeChild(widget.node!);
+    this.parent!.node.removeChild(widget.node);
   }
 
   /**

--- a/src/ui/splitpanel.ts
+++ b/src/ui/splitpanel.ts
@@ -333,7 +333,7 @@ class SplitPanel extends Panel {
     if (layout.orientation === 'horizontal') {
       pos = event.clientX - rect.left - this._pressData.delta;
     } else {
-      pos = event.clientY - rect.top - this._pressData.delta;
+      pos = event.clientY - rect.top - pressData.delta;
     }
 
     // Set the handle as close to the desired position as possible.
@@ -379,7 +379,7 @@ class SplitPanel extends Panel {
     document.removeEventListener('contextmenu', this, true);
   }
 
-  private _pressData: Private.IPressData = null;
+  private _pressData: Private.IPressData | null = null;
 }
 
 
@@ -734,7 +734,7 @@ class SplitLayout extends PanelLayout {
    */
   protected detachWidget(index: number, widget: Widget): void {
     // Remove the handle for the widget.
-    let handle = this._handles.removeAt(index);
+    let handle = this._handles.removeAt(index)!;
 
     // Remove the sizer for the widget.
     this._sizers.removeAt(index);
@@ -836,7 +836,7 @@ class SplitLayout extends PanelLayout {
     // Update the handles and track the visible widget count.
     let nVisible = 0;
     let widgets = this.widgets;
-    let lastHandle: HTMLDivElement = null;
+    let lastHandle: HTMLDivElement | null = null;
     for (let i = 0, n = widgets.length; i < n; ++i) {
       let handle = this._handles.at(i);
       if (widgets.at(i).isHidden) {
@@ -1009,7 +1009,7 @@ class SplitLayout extends PanelLayout {
   private _spacing = 4;
   private _dirty = false;
   private _hasNormedSizes = false;
-  private _box: IBoxSizing = null;
+  private _box: IBoxSizing | null = null;
   private _renderer: SplitLayout.IRenderer;
   private _sizers = new Vector<BoxSizer>();
   private _handles = new Vector<HTMLDivElement>();
@@ -1075,7 +1075,7 @@ namespace SplitLayout {
    */
   export
   function getStretch(widget: Widget): number {
-    return Private.stretchProperty.get(widget);
+    return Private.stretchProperty.get(widget)!;
   }
 
   /**
@@ -1303,7 +1303,6 @@ namespace Private {
    */
   function onChildPropertyChanged(child: Widget): void {
     let parent = child.parent;
-    let layout = parent && parent.layout;
-    if (layout instanceof SplitLayout) parent.fit();
+    if (parent && parent.layout instanceof SplitLayout) parent.fit();
   }
 }

--- a/src/ui/splitpanel.ts
+++ b/src/ui/splitpanel.ts
@@ -234,14 +234,14 @@ class SplitPanel extends Panel {
    * A message handler invoked on an `'after-attach'` message.
    */
   protected onAfterAttach(msg: Message): void {
-    this.node!.addEventListener('mousedown', this);
+    this.node.addEventListener('mousedown', this);
   }
 
   /**
    * A message handler invoked on a `'before-detach'` message.
    */
   protected onBeforeDetach(msg: Message): void {
-    this.node!.removeEventListener('mousedown', this);
+    this.node.removeEventListener('mousedown', this);
     this._releaseMouse();
   }
 
@@ -329,7 +329,7 @@ class SplitPanel extends Panel {
     // Compute the desired offset position for the handle.
     let pos: number;
     let layout = this.layout as SplitLayout;
-    let rect = this.node!.getBoundingClientRect();
+    let rect = this.node.getBoundingClientRect();
     let pressData = this._pressData!;
     if (layout.orientation === 'horizontal') {
       pos = event.clientX - rect.left - pressData.delta;
@@ -692,15 +692,15 @@ class SplitLayout extends PanelLayout {
     Widget.prepareGeometry(widget);
 
     // Add the widget and handle nodes to the parent.
-    let node = this.parent!.node!;
-    node.appendChild(widget.node!);
-    node.appendChild(handle);
+    let parent = this.parent!;
+    parent.node.appendChild(widget.node);
+    parent.node.appendChild(handle);
 
     // Send an `'after-attach'` message if the parent is attached.
-    if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
+    if (parent.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
 
     // Post a layout request for the parent widget.
-    this.parent!.fit();
+    parent.fit();
   }
 
   /**
@@ -742,18 +742,18 @@ class SplitLayout extends PanelLayout {
     this._sizers.removeAt(index);
 
     // Send a `'before-detach'` message if the parent is attached.
-    if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
+    let parent = this.parent!;
+    if (parent.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
 
     // Remove the widget and handle nodes from the parent.
-    let node = this.parent!.node!;
-    node.removeChild(widget.node!);
-    node.removeChild(handle);
+    parent.node.removeChild(widget.node);
+    parent.node.removeChild(handle);
 
     // Reset the layout geometry for the widget.
     Widget.resetGeometry(widget);
 
     // Post a layout request for the parent widget.
-    this.parent!.fit();
+    parent.fit();
   }
 
   /**
@@ -883,7 +883,7 @@ class SplitLayout extends PanelLayout {
         sizer.maxSize = 0;
         continue;
       }
-      let limits = sizeLimits(widget.node!);
+      let limits = sizeLimits(widget.node);
       sizer.stretch = SplitLayout.getStretch(widget);
       if (horz) {
         sizer.minSize = limits.minWidth;
@@ -903,14 +903,14 @@ class SplitLayout extends PanelLayout {
     }
 
     // Update the box sizing and add it to the size constraints.
-    let box = this._box = boxSizing(this.parent!.node!);
+    let box = this._box = boxSizing(this.parent!.node);
     minW += box.horizontalSum;
     minH += box.verticalSum;
     maxW += box.horizontalSum;
     maxH += box.verticalSum;
 
     // Update the parent's size constraints.
-    let style = this.parent!.node!.style;
+    let style = this.parent!.node.style;
     style.minWidth = `${minW}px`;
     style.minHeight = `${minH}px`;
     style.maxWidth = maxW === Infinity ? 'none' : `${maxW}px`;
@@ -945,16 +945,15 @@ class SplitLayout extends PanelLayout {
     }
 
     // Measure the parent if the offset dimensions are unknown.
-    let node = this.parent!.node!;
     if (offsetWidth < 0) {
-      offsetWidth = node.offsetWidth;
+      offsetWidth = this.parent!.node.offsetWidth;
     }
     if (offsetHeight < 0) {
-      offsetHeight = node.offsetHeight;
+      offsetHeight = this.parent!.node.offsetHeight;
     }
 
     // Ensure the parent box sizing data is computed.
-    let box = this._box || (this._box = boxSizing(node));
+    let box = this._box || (this._box = boxSizing(this.parent!.node));
 
     // Compute the actual layout bounds adjusted for border and padding.
     let top = box.paddingTop;

--- a/src/ui/splitpanel.ts
+++ b/src/ui/splitpanel.ts
@@ -234,14 +234,14 @@ class SplitPanel extends Panel {
    * A message handler invoked on an `'after-attach'` message.
    */
   protected onAfterAttach(msg: Message): void {
-    this.node.addEventListener('mousedown', this);
+    this.node!.addEventListener('mousedown', this);
   }
 
   /**
    * A message handler invoked on a `'before-detach'` message.
    */
   protected onBeforeDetach(msg: Message): void {
-    this.node.removeEventListener('mousedown', this);
+    this.node!.removeEventListener('mousedown', this);
     this._releaseMouse();
   }
 
@@ -329,7 +329,7 @@ class SplitPanel extends Panel {
     // Compute the desired offset position for the handle.
     let pos: number;
     let layout = this.layout as SplitLayout;
-    let rect = this.node.getBoundingClientRect();
+    let rect = this.node!.getBoundingClientRect();
     let pressData = this._pressData!;
     if (layout.orientation === 'horizontal') {
       pos = event.clientX - rect.left - pressData.delta;
@@ -692,14 +692,15 @@ class SplitLayout extends PanelLayout {
     Widget.prepareGeometry(widget);
 
     // Add the widget and handle nodes to the parent.
-    this.parent.node.appendChild(widget.node);
-    this.parent.node.appendChild(handle);
+    let node = this.parent!.node!;
+    node.appendChild(widget.node!);
+    node.appendChild(handle);
 
     // Send an `'after-attach'` message if the parent is attached.
-    if (this.parent.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
+    if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
 
     // Post a layout request for the parent widget.
-    this.parent.fit();
+    this.parent!.fit();
   }
 
   /**
@@ -720,7 +721,7 @@ class SplitLayout extends PanelLayout {
     move(this._handles, fromIndex, toIndex);
 
     // Post a fit request to the parent to show/hide last handle.
-    this.parent.fit();
+    this.parent!.fit();
   }
 
   /**
@@ -741,17 +742,18 @@ class SplitLayout extends PanelLayout {
     this._sizers.removeAt(index);
 
     // Send a `'before-detach'` message if the parent is attached.
-    if (this.parent.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
+    if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
 
     // Remove the widget and handle nodes from the parent.
-    this.parent.node.removeChild(widget.node);
-    this.parent.node.removeChild(handle);
+    let node = this.parent!.node!;
+    node.removeChild(widget.node!);
+    node.removeChild(handle);
 
     // Reset the layout geometry for the widget.
     Widget.resetGeometry(widget);
 
     // Post a layout request for the parent widget.
-    this.parent.fit();
+    this.parent!.fit();
   }
 
   /**
@@ -761,7 +763,7 @@ class SplitLayout extends PanelLayout {
    * This is called when the layout is installed on its parent.
    */
   protected onLayoutChanged(msg: Message): void {
-    Private.toggleOrientation(this.parent, this.orientation);
+    Private.toggleOrientation(this.parent!, this.orientation);
     super.onLayoutChanged(msg);
   }
 
@@ -770,7 +772,7 @@ class SplitLayout extends PanelLayout {
    */
   protected onAfterShow(msg: Message): void {
     super.onAfterShow(msg);
-    this.parent.update();
+    this.parent!.update();
   }
 
   /**
@@ -778,7 +780,7 @@ class SplitLayout extends PanelLayout {
    */
   protected onAfterAttach(msg: Message): void {
     super.onAfterAttach(msg);
-    this.parent.fit();
+    this.parent!.fit();
   }
 
   /**
@@ -786,9 +788,9 @@ class SplitLayout extends PanelLayout {
    */
   protected onChildShown(msg: ChildMessage): void {
     if (IS_IE) { // prevent flicker on IE
-      sendMessage(this.parent, WidgetMessage.FitRequest);
+      sendMessage(this.parent!, WidgetMessage.FitRequest);
     } else {
-      this.parent.fit();
+      this.parent!.fit();
     }
   }
 
@@ -797,9 +799,9 @@ class SplitLayout extends PanelLayout {
    */
   protected onChildHidden(msg: ChildMessage): void {
     if (IS_IE) { // prevent flicker on IE
-      sendMessage(this.parent, WidgetMessage.FitRequest);
+      sendMessage(this.parent!, WidgetMessage.FitRequest);
     } else {
-      this.parent.fit();
+      this.parent!.fit();
     }
   }
 
@@ -807,7 +809,7 @@ class SplitLayout extends PanelLayout {
    * A message handler invoked on a `'resize'` message.
    */
   protected onResize(msg: ResizeMessage): void {
-    if (this.parent.isVisible) {
+    if (this.parent!.isVisible) {
       this._update(msg.width, msg.height);
     }
   }
@@ -816,7 +818,7 @@ class SplitLayout extends PanelLayout {
    * A message handler invoked on an `'update-request'` message.
    */
   protected onUpdateRequest(msg: Message): void {
-    if (this.parent.isVisible) {
+    if (this.parent!.isVisible) {
       this._update(-1, -1);
     }
   }
@@ -825,7 +827,7 @@ class SplitLayout extends PanelLayout {
    * A message handler invoked on a `'fit-request'` message.
    */
   protected onFitRequest(msg: Message): void {
-    if (this.parent.isAttached) {
+    if (this.parent!.isAttached) {
       this._fit();
     }
   }
@@ -881,7 +883,7 @@ class SplitLayout extends PanelLayout {
         sizer.maxSize = 0;
         continue;
       }
-      let limits = sizeLimits(widget.node);
+      let limits = sizeLimits(widget.node!);
       sizer.stretch = SplitLayout.getStretch(widget);
       if (horz) {
         sizer.minSize = limits.minWidth;
@@ -901,14 +903,14 @@ class SplitLayout extends PanelLayout {
     }
 
     // Update the box sizing and add it to the size constraints.
-    let box = this._box = boxSizing(this.parent.node);
+    let box = this._box = boxSizing(this.parent!.node!);
     minW += box.horizontalSum;
     minH += box.verticalSum;
     maxW += box.horizontalSum;
     maxH += box.verticalSum;
 
     // Update the parent's size constraints.
-    let style = this.parent.node.style;
+    let style = this.parent!.node!.style;
     style.minWidth = `${minW}px`;
     style.minHeight = `${minH}px`;
     style.maxWidth = maxW === Infinity ? 'none' : `${maxW}px`;
@@ -919,12 +921,12 @@ class SplitLayout extends PanelLayout {
 
     // Notify the ancestor that it should fit immediately. This may
     // cause a resize of the parent, fulfilling the required update.
-    let ancestor = this.parent.parent;
+    let ancestor = this.parent!.parent;
     if (ancestor) sendMessage(ancestor, WidgetMessage.FitRequest);
 
     // If the dirty flag is still set, the parent was not resized.
     // Trigger the required update on the parent widget immediately.
-    if (this._dirty) sendMessage(this.parent, WidgetMessage.UpdateRequest);
+    if (this._dirty) sendMessage(this.parent!, WidgetMessage.UpdateRequest);
   }
 
   /**
@@ -943,15 +945,16 @@ class SplitLayout extends PanelLayout {
     }
 
     // Measure the parent if the offset dimensions are unknown.
+    let node = this.parent!.node!;
     if (offsetWidth < 0) {
-      offsetWidth = this.parent.node.offsetWidth;
+      offsetWidth = node.offsetWidth;
     }
     if (offsetHeight < 0) {
-      offsetHeight = this.parent.node.offsetHeight;
+      offsetHeight = node.offsetHeight;
     }
 
     // Ensure the parent box sizing data is computed.
-    let box = this._box || (this._box = boxSizing(this.parent.node));
+    let box = this._box || (this._box = boxSizing(node));
 
     // Compute the actual layout bounds adjusted for border and padding.
     let top = box.paddingTop;

--- a/src/ui/splitpanel.ts
+++ b/src/ui/splitpanel.ts
@@ -330,14 +330,15 @@ class SplitPanel extends Panel {
     let pos: number;
     let layout = this.layout as SplitLayout;
     let rect = this.node.getBoundingClientRect();
+    let pressData = this._pressData!;
     if (layout.orientation === 'horizontal') {
-      pos = event.clientX - rect.left - this._pressData.delta;
+      pos = event.clientX - rect.left - pressData.delta;
     } else {
       pos = event.clientY - rect.top - pressData.delta;
     }
 
     // Set the handle as close to the desired position as possible.
-    layout.setHandlePosition(this._pressData.index, pos);
+    layout.setHandlePosition(pressData.index, pos);
   }
 
   /**

--- a/src/ui/stackedpanel.ts
+++ b/src/ui/stackedpanel.ts
@@ -345,7 +345,7 @@ class StackedLayout extends PanelLayout {
   }
 
   private _dirty = false;
-  private _box: IBoxSizing = null;
+  private _box: IBoxSizing | null = null;
 }
 
 

--- a/src/ui/stackedpanel.ts
+++ b/src/ui/stackedpanel.ts
@@ -128,13 +128,13 @@ class StackedLayout extends PanelLayout {
     Widget.prepareGeometry(widget);
 
     // Add the widget's node to the parent.
-    this.parent.node.appendChild(widget.node);
+    this.parent!.node!.appendChild(widget.node!);
 
     // Send an `'after-attach'` message if the parent is attached.
-    if (this.parent.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
+    if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
 
     // Post a layout request for the parent widget.
-    this.parent.fit();
+    this.parent!.fit();
   }
 
   /**
@@ -151,7 +151,7 @@ class StackedLayout extends PanelLayout {
    */
   protected moveWidget(fromIndex: number, toIndex: number, widget: Widget): void {
     // Post an update request for the parent widget.
-    this.parent.update();
+    this.parent!.update();
   }
 
   /**
@@ -166,19 +166,19 @@ class StackedLayout extends PanelLayout {
    */
   protected detachWidget(index: number, widget: Widget): void {
     // Send a `'before-detach'` message if the parent is attached.
-    if (this.parent.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
+    if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
 
     // Remove the widget's node from the parent.
-    this.parent.node.removeChild(widget.node);
+    this.parent!.node!.removeChild(widget.node!);
 
     // Reset the layout geometry for the widget.
     Widget.resetGeometry(widget);
 
     // Reset the z-index for the widget.
-    widget.node.style.zIndex = '';
+    widget.node!.style.zIndex = '';
 
     // Post a layout request for the parent widget.
-    this.parent.fit();
+    this.parent!.fit();
   }
 
   /**
@@ -186,7 +186,7 @@ class StackedLayout extends PanelLayout {
    */
   protected onAfterShow(msg: Message): void {
     super.onAfterShow(msg);
-    this.parent.update();
+    this.parent!.update();
   }
 
   /**
@@ -194,7 +194,7 @@ class StackedLayout extends PanelLayout {
    */
   protected onAfterAttach(msg: Message): void {
     super.onAfterAttach(msg);
-    this.parent.fit();
+    this.parent!.fit();
   }
 
   /**
@@ -202,9 +202,9 @@ class StackedLayout extends PanelLayout {
    */
   protected onChildShown(msg: ChildMessage): void {
     if (IS_IE) { // prevent flicker on IE
-      sendMessage(this.parent, WidgetMessage.FitRequest);
+      sendMessage(this.parent!, WidgetMessage.FitRequest);
     } else {
-      this.parent.fit();
+      this.parent!.fit();
     }
   }
 
@@ -213,9 +213,9 @@ class StackedLayout extends PanelLayout {
    */
   protected onChildHidden(msg: ChildMessage): void {
     if (IS_IE) { // prevent flicker on IE
-      sendMessage(this.parent, WidgetMessage.FitRequest);
+      sendMessage(this.parent!, WidgetMessage.FitRequest);
     } else {
-      this.parent.fit();
+      this.parent!.fit();
     }
   }
 
@@ -223,7 +223,7 @@ class StackedLayout extends PanelLayout {
    * A message handler invoked on a `'resize'` message.
    */
   protected onResize(msg: ResizeMessage): void {
-    if (this.parent.isVisible) {
+    if (this.parent!.isVisible) {
       this._update(msg.width, msg.height);
     }
   }
@@ -232,7 +232,7 @@ class StackedLayout extends PanelLayout {
    * A message handler invoked on an `'update-request'` message.
    */
   protected onUpdateRequest(msg: Message): void {
-    if (this.parent.isVisible) {
+    if (this.parent!.isVisible) {
       this._update(-1, -1);
     }
   }
@@ -241,7 +241,7 @@ class StackedLayout extends PanelLayout {
    * A message handler invoked on a `'fit-request'` message.
    */
   protected onFitRequest(msg: Message): void {
-    if (this.parent.isAttached) {
+    if (this.parent!.isAttached) {
       this._fit();
     }
   }
@@ -263,7 +263,7 @@ class StackedLayout extends PanelLayout {
       if (widget.isHidden) {
         continue;
       }
-      let limits = sizeLimits(widget.node);
+      let limits = sizeLimits(widget.node!);
       minW = Math.max(minW, limits.minWidth);
       minH = Math.max(minH, limits.minHeight);
       maxW = Math.min(maxW, limits.maxWidth);
@@ -275,14 +275,14 @@ class StackedLayout extends PanelLayout {
     maxH = Math.max(minH, maxH);
 
     // Update the box sizing and add it to the size constraints.
-    let box = this._box = boxSizing(this.parent.node);
+    let box = this._box = boxSizing(this.parent!.node!);
     minW += box.horizontalSum;
     minH += box.verticalSum;
     maxW += box.horizontalSum;
     maxH += box.verticalSum;
 
     // Update the parent's size constraints.
-    let style = this.parent.node.style;
+    let style = this.parent!.node!.style;
     style.minWidth = `${minW}px`;
     style.minHeight = `${minH}px`;
     style.maxWidth = maxW === Infinity ? 'none' : `${maxW}px`;
@@ -293,12 +293,12 @@ class StackedLayout extends PanelLayout {
 
     // Notify the ancestor that it should fit immediately. This may
     // cause a resize of the parent, fulfilling the required update.
-    let ancestor = this.parent.parent;
+    let ancestor = this.parent!.parent;
     if (ancestor) sendMessage(ancestor, WidgetMessage.FitRequest);
 
     // If the dirty flag is still set, the parent was not resized.
     // Trigger the required update on the parent widget immediately.
-    if (this._dirty) sendMessage(this.parent, WidgetMessage.UpdateRequest);
+    if (this._dirty) sendMessage(this.parent!, WidgetMessage.UpdateRequest);
   }
 
   /**
@@ -317,15 +317,16 @@ class StackedLayout extends PanelLayout {
     }
 
     // Measure the parent if the offset dimensions are unknown.
+    let parentNode = this.parent!.node!;
     if (offsetWidth < 0) {
-      offsetWidth = this.parent.node.offsetWidth;
+      offsetWidth = parentNode.offsetWidth;
     }
     if (offsetHeight < 0) {
-      offsetHeight = this.parent.node.offsetHeight;
+      offsetHeight = parentNode.offsetHeight;
     }
 
     // Ensure the parent box sizing data is computed.
-    let box = this._box || (this._box = boxSizing(this.parent.node));
+    let box = this._box || (this._box = boxSizing(parentNode));
 
     // Compute the actual layout bounds adjusted for border and padding.
     let top = box.paddingTop;
@@ -339,7 +340,7 @@ class StackedLayout extends PanelLayout {
       if (widget.isHidden) {
         continue;
       }
-      widget.node.style.zIndex = `${i}`;
+      widget.node!.style.zIndex = `${i}`;
       Widget.setGeometry(widget, left, top, width, height);
     }
   }

--- a/src/ui/stackedpanel.ts
+++ b/src/ui/stackedpanel.ts
@@ -128,13 +128,14 @@ class StackedLayout extends PanelLayout {
     Widget.prepareGeometry(widget);
 
     // Add the widget's node to the parent.
-    this.parent!.node!.appendChild(widget.node!);
+    let parent = this.parent!;
+    parent.node.appendChild(widget.node);
 
     // Send an `'after-attach'` message if the parent is attached.
-    if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
+    if (parent.isAttached) sendMessage(widget, WidgetMessage.AfterAttach);
 
     // Post a layout request for the parent widget.
-    this.parent!.fit();
+    parent.fit();
   }
 
   /**
@@ -166,19 +167,20 @@ class StackedLayout extends PanelLayout {
    */
   protected detachWidget(index: number, widget: Widget): void {
     // Send a `'before-detach'` message if the parent is attached.
-    if (this.parent!.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
+    let parent = this.parent!;
+    if (parent.isAttached) sendMessage(widget, WidgetMessage.BeforeDetach);
 
     // Remove the widget's node from the parent.
-    this.parent!.node!.removeChild(widget.node!);
+    parent.node.removeChild(widget.node);
 
     // Reset the layout geometry for the widget.
     Widget.resetGeometry(widget);
 
     // Reset the z-index for the widget.
-    widget.node!.style.zIndex = '';
+    widget.node.style.zIndex = '';
 
     // Post a layout request for the parent widget.
-    this.parent!.fit();
+    parent.fit();
   }
 
   /**
@@ -263,7 +265,7 @@ class StackedLayout extends PanelLayout {
       if (widget.isHidden) {
         continue;
       }
-      let limits = sizeLimits(widget.node!);
+      let limits = sizeLimits(widget.node);
       minW = Math.max(minW, limits.minWidth);
       minH = Math.max(minH, limits.minHeight);
       maxW = Math.min(maxW, limits.maxWidth);
@@ -275,14 +277,15 @@ class StackedLayout extends PanelLayout {
     maxH = Math.max(minH, maxH);
 
     // Update the box sizing and add it to the size constraints.
-    let box = this._box = boxSizing(this.parent!.node!);
+    let parent = this.parent!;
+    let box = this._box = boxSizing(parent.node);
     minW += box.horizontalSum;
     minH += box.verticalSum;
     maxW += box.horizontalSum;
     maxH += box.verticalSum;
 
     // Update the parent's size constraints.
-    let style = this.parent!.node!.style;
+    let style = parent.node.style;
     style.minWidth = `${minW}px`;
     style.minHeight = `${minH}px`;
     style.maxWidth = maxW === Infinity ? 'none' : `${maxW}px`;
@@ -293,12 +296,12 @@ class StackedLayout extends PanelLayout {
 
     // Notify the ancestor that it should fit immediately. This may
     // cause a resize of the parent, fulfilling the required update.
-    let ancestor = this.parent!.parent;
+    let ancestor = parent.parent;
     if (ancestor) sendMessage(ancestor, WidgetMessage.FitRequest);
 
     // If the dirty flag is still set, the parent was not resized.
     // Trigger the required update on the parent widget immediately.
-    if (this._dirty) sendMessage(this.parent!, WidgetMessage.UpdateRequest);
+    if (this._dirty) sendMessage(parent, WidgetMessage.UpdateRequest);
   }
 
   /**
@@ -317,16 +320,16 @@ class StackedLayout extends PanelLayout {
     }
 
     // Measure the parent if the offset dimensions are unknown.
-    let parentNode = this.parent!.node!;
+    let parent = this.parent!;
     if (offsetWidth < 0) {
-      offsetWidth = parentNode.offsetWidth;
+      offsetWidth = parent.node.offsetWidth;
     }
     if (offsetHeight < 0) {
-      offsetHeight = parentNode.offsetHeight;
+      offsetHeight = parent.node.offsetHeight;
     }
 
     // Ensure the parent box sizing data is computed.
-    let box = this._box || (this._box = boxSizing(parentNode));
+    let box = this._box || (this._box = boxSizing(parent.node));
 
     // Compute the actual layout bounds adjusted for border and padding.
     let top = box.paddingTop;
@@ -340,7 +343,7 @@ class StackedLayout extends PanelLayout {
       if (widget.isHidden) {
         continue;
       }
-      widget.node!.style.zIndex = `${i}`;
+      widget.node.style.zIndex = `${i}`;
       Widget.setGeometry(widget, left, top, width, height);
     }
   }

--- a/src/ui/tabbar.ts
+++ b/src/ui/tabbar.ts
@@ -410,7 +410,7 @@ class TabBar extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get renderer(): TabBar.IRenderer {
+  get renderer(): TabBar.IRenderer | null {
     return this._renderer;
   }
 

--- a/src/ui/tabbar.ts
+++ b/src/ui/tabbar.ts
@@ -1540,7 +1540,7 @@ namespace Private {
     /**
      * The tab node being dragged.
      */
-    tab: HTMLElement = null;
+    tab: HTMLElement;
 
     /**
      * The index of the tab being dragged.
@@ -1570,7 +1570,7 @@ namespace Private {
     /**
      * The array of tab layout objects snapped at drag start.
      */
-    tabLayout: ITabLayout[] = null;
+    tabLayout: ITabLayout[];
 
     /**
      * The mouse press client X position.
@@ -1585,12 +1585,12 @@ namespace Private {
     /**
      * The bounding client rect of the tab bar content node.
      */
-    contentRect: ClientRect = null;
+    contentRect: ClientRect;
 
     /**
      * The disposable to clean up the cursor override.
      */
-    override: IDisposable = null;
+    override: IDisposable;
 
     /**
      * Whether the drag is currently active.

--- a/src/ui/tabbar.ts
+++ b/src/ui/tabbar.ts
@@ -237,7 +237,7 @@ class TabBar extends Widget {
    * #### Notes
    * This will be `null` if no tab is selected.
    */
-  get currentTitle(): Title {
+  get currentTitle(): Title | null {
     let i = this._currentIndex;
     return i !== -1 ? this._titles.at(i) : null;
   }
@@ -248,7 +248,7 @@ class TabBar extends Widget {
    * #### Notes
    * If the title does not exist, the title will be set to `null`.
    */
-  set currentTitle(value: Title) {
+  set currentTitle(value: Title | null) {
     this.currentIndex = indexOf(this._titles, value);
   }
 
@@ -518,7 +518,7 @@ class TabBar extends Widget {
    * @returns The title occupying the index, or `null` if the index
    *   is out of range.
    */
-  removeTabAt(index: number): Title {
+  removeTabAt(index: number): Title | null {
     // Bail if the index is out of range.
     let i = Math.floor(index);
     if (i < 0 || i >= this._titles.length) {
@@ -529,7 +529,7 @@ class TabBar extends Widget {
     this._releaseMouse();
 
     // Remove the title from the vector.
-    let title = this._titles.removeAt(i);
+    let title = this._titles.removeAt(i)!;
 
     // Disconnect from the title changed signal.
     title.changed.disconnect(this._onTitleChanged, this);
@@ -1104,11 +1104,11 @@ class TabBar extends Widget {
   private _currentIndex = -1;
   private _tabsMovable: boolean;
   private _allowDeselect: boolean;
-  private _renderer: TabBar.IRenderer;
-  private _previousTitle: Title = null;
+  private _renderer: TabBar.IRenderer | null;
+  private _previousTitle: Title | null = null;
   private _titles = new Vector<Title>();
   private _orientation: TabBar.Orientation;
-  private _dragData: Private.DragData = null;
+  private _dragData: Private.DragData | null = null;
   private _insertBehavior: TabBar.InsertBehavior;
   private _removeBehavior: TabBar.RemoveBehavior;
 }
@@ -1254,7 +1254,7 @@ namespace TabBar {
     /**
      * The previously selected title.
      */
-    previousTitle: Title;
+    previousTitle: Title | null;
 
     /**
      * The currently selected index.
@@ -1264,7 +1264,7 @@ namespace TabBar {
     /**
      * The currently selected title.
      */
-    currentTitle: Title;
+    currentTitle: Title | null;
   }
 
   /**
@@ -1643,7 +1643,7 @@ namespace Private {
   export
   function parseTransitionDuration(tab: HTMLElement): number {
     let style = window.getComputedStyle(tab);
-    return 1000 * (parseFloat(style.transitionDuration) || 0);
+    return 1000 * (parseFloat(style.transitionDuration!) || 0);
   }
 
   /**
@@ -1658,7 +1658,7 @@ namespace Private {
         let pos = node.offsetLeft;
         let size = node.offsetWidth;
         let cstyle = window.getComputedStyle(node);
-        let margin = parseInt(cstyle.marginLeft, 10) || 0;
+        let margin = parseInt(cstyle.marginLeft!, 10) || 0;
         layout[i] = { margin, pos, size };
       }
     } else {
@@ -1667,7 +1667,7 @@ namespace Private {
         let pos = node.offsetTop;
         let size = node.offsetHeight;
         let cstyle = window.getComputedStyle(node);
-        let margin = parseInt(cstyle.marginTop, 10) || 0;
+        let margin = parseInt(cstyle.marginTop!, 10) || 0;
         layout[i] = { margin, pos, size };
       }
     }

--- a/src/ui/tabbar.ts
+++ b/src/ui/tabbar.ts
@@ -157,7 +157,7 @@ class TabBar extends Widget {
   dispose(): void {
     this._releaseMouse();
     this._titles.clear();
-    this._renderer = null;
+    this._renderer = null!;  // Do not type check null
     this._previousTitle = null;
     super.dispose();
   }
@@ -218,7 +218,7 @@ class TabBar extends Widget {
    * This is a read-only property.
    */
   get contentNode(): HTMLUListElement {
-    return this.node!.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
+    return this.node.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
   }
 
   /**
@@ -410,7 +410,7 @@ class TabBar extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get renderer(): TabBar.IRenderer | null {
+  get renderer(): TabBar.IRenderer {
     return this._renderer;
   }
 
@@ -642,18 +642,16 @@ class TabBar extends Widget {
    * A message handler invoked on an `'after-attach'` message.
    */
   protected onAfterAttach(msg: Message): void {
-    let node = this.node!;
-    node.addEventListener('click', this);
-    node.addEventListener('mousedown', this);
+    this.node.addEventListener('click', this);
+    this.node.addEventListener('mousedown', this);
   }
 
   /**
    * A message handler invoked on a `'before-detach'` message.
    */
   protected onBeforeDetach(msg: Message): void {
-    let node = this.node!;
-    node.removeEventListener('click', this);
-    node.removeEventListener('mousedown', this);
+    this.node.removeEventListener('click', this);
+    this.node.removeEventListener('mousedown', this);
     this._releaseMouse();
   }
 
@@ -663,7 +661,7 @@ class TabBar extends Widget {
   protected onUpdateRequest(msg: Message): void {
     let content: VNode[] = [];
     let titles = this._titles;
-    let renderer = this._renderer!;
+    let renderer = this._renderer;
     let currentTitle = this.currentTitle;
     for (let i = 0, n = titles.length; i < n; ++i) {
       let title = titles.at(i);
@@ -722,7 +720,7 @@ class TabBar extends Widget {
     }
 
     // Ignore the click if it was not on a close icon.
-    let icon = tabs[i].querySelector(this._renderer!.closeIconSelector);
+    let icon = tabs[i].querySelector(this._renderer.closeIconSelector);
     if (!icon || !icon.contains(event.target as HTMLElement)) {
       return;
     }
@@ -761,7 +759,7 @@ class TabBar extends Widget {
     event.stopPropagation();
 
     // Ignore the press if it was on a close icon.
-    let icon = tabs[i].querySelector(this._renderer!.closeIconSelector);
+    let icon = tabs[i].querySelector(this._renderer.closeIconSelector);
     if (icon && icon.contains(event.target as HTMLElement)) {
       return;
     }
@@ -1106,7 +1104,7 @@ class TabBar extends Widget {
   private _currentIndex = -1;
   private _tabsMovable: boolean;
   private _allowDeselect: boolean;
-  private _renderer: TabBar.IRenderer | null;
+  private _renderer: TabBar.IRenderer;
   private _previousTitle: Title | null = null;
   private _titles = new Vector<Title>();
   private _orientation: TabBar.Orientation;

--- a/src/ui/tabbar.ts
+++ b/src/ui/tabbar.ts
@@ -218,7 +218,7 @@ class TabBar extends Widget {
    * This is a read-only property.
    */
   get contentNode(): HTMLUListElement {
-    return this.node.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
+    return this.node!.getElementsByClassName(CONTENT_CLASS)[0] as HTMLUListElement;
   }
 
   /**
@@ -642,16 +642,18 @@ class TabBar extends Widget {
    * A message handler invoked on an `'after-attach'` message.
    */
   protected onAfterAttach(msg: Message): void {
-    this.node.addEventListener('click', this);
-    this.node.addEventListener('mousedown', this);
+    let node = this.node!;
+    node.addEventListener('click', this);
+    node.addEventListener('mousedown', this);
   }
 
   /**
    * A message handler invoked on a `'before-detach'` message.
    */
   protected onBeforeDetach(msg: Message): void {
-    this.node.removeEventListener('click', this);
-    this.node.removeEventListener('mousedown', this);
+    let node = this.node!;
+    node.removeEventListener('click', this);
+    node.removeEventListener('mousedown', this);
     this._releaseMouse();
   }
 
@@ -661,7 +663,7 @@ class TabBar extends Widget {
   protected onUpdateRequest(msg: Message): void {
     let content: VNode[] = [];
     let titles = this._titles;
-    let renderer = this._renderer;
+    let renderer = this._renderer!;
     let currentTitle = this.currentTitle;
     for (let i = 0, n = titles.length; i < n; ++i) {
       let title = titles.at(i);
@@ -720,7 +722,7 @@ class TabBar extends Widget {
     }
 
     // Ignore the click if it was not on a close icon.
-    let icon = tabs[i].querySelector(this._renderer.closeIconSelector);
+    let icon = tabs[i].querySelector(this._renderer!.closeIconSelector);
     if (!icon || !icon.contains(event.target as HTMLElement)) {
       return;
     }
@@ -759,7 +761,7 @@ class TabBar extends Widget {
     event.stopPropagation();
 
     // Ignore the press if it was on a close icon.
-    let icon = tabs[i].querySelector(this._renderer.closeIconSelector);
+    let icon = tabs[i].querySelector(this._renderer!.closeIconSelector);
     if (icon && icon.contains(event.target as HTMLElement)) {
       return;
     }

--- a/src/ui/tabpanel.ts
+++ b/src/ui/tabpanel.ts
@@ -335,8 +335,8 @@ class TabPanel extends Widget {
     this._tabBar.removeTab(widget.title);
   }
 
-  private _tabBar: TabBar;
-  private _stackedPanel: StackedPanel;
+  private _tabBar: TabBar | null;
+  private _stackedPanel: StackedPanel | null;
   private _tabPlacement: TabPanel.TabPlacement;
 }
 
@@ -416,7 +416,7 @@ namespace TabPanel {
     /**
      * The previously selected widget.
      */
-    previousWidget: Widget;
+    previousWidget: Widget | null;
 
     /**
      * The currently selected index.
@@ -426,7 +426,7 @@ namespace TabPanel {
     /**
      * The currently selected widget.
      */
-    currentWidget: Widget;
+    currentWidget: Widget | null;
   }
 }
 

--- a/src/ui/tabpanel.ts
+++ b/src/ui/tabpanel.ts
@@ -154,7 +154,7 @@ class TabPanel extends Widget {
    * #### Notes
    * This will be `null` if there is no selected tab.
    */
-  get currentWidget(): Widget {
+  get currentWidget(): Widget | null {
     let title = this._tabBar.currentTitle;
     return title ? title.owner as Widget : null;
   }
@@ -165,7 +165,7 @@ class TabPanel extends Widget {
    * #### Notes
    * If the widget is not in the panel, it will be set to `null`.
    */
-  set currentWidget(value: Widget) {
+  set currentWidget(value: Widget | null) {
     this._tabBar.currentTitle = value ? value.title : null;
   }
 
@@ -236,7 +236,7 @@ class TabPanel extends Widget {
    *
    * This is a read-only property.
    */
-  get tabBar(): TabBar {
+  get tabBar(): TabBar | null {
     return this._tabBar;
   }
 
@@ -248,7 +248,7 @@ class TabPanel extends Widget {
    *
    * This is a read-only property.
    */
-  get stackedPanel(): StackedPanel {
+  get stackedPanel(): StackedPanel | null {
     return this._stackedPanel;
   }
 

--- a/src/ui/tabpanel.ts
+++ b/src/ui/tabpanel.ts
@@ -135,7 +135,7 @@ class TabPanel extends Widget {
    * This will be `-1` if no tab is selected.
    */
   get currentIndex(): number {
-    return this._tabBar.currentIndex;
+    return this._tabBar!.currentIndex;
   }
 
   /**
@@ -145,7 +145,7 @@ class TabPanel extends Widget {
    * If the index is out of range, it will be set to `-1`.
    */
   set currentIndex(value: number) {
-    this._tabBar.currentIndex = value;
+    this._tabBar!.currentIndex = value;
   }
 
   /**
@@ -155,7 +155,7 @@ class TabPanel extends Widget {
    * This will be `null` if there is no selected tab.
    */
   get currentWidget(): Widget | null {
-    let title = this._tabBar.currentTitle;
+    let title = this._tabBar!.currentTitle;
     return title ? title.owner as Widget : null;
   }
 
@@ -166,7 +166,7 @@ class TabPanel extends Widget {
    * If the widget is not in the panel, it will be set to `null`.
    */
   set currentWidget(value: Widget | null) {
-    this._tabBar.currentTitle = value ? value.title : null;
+    this._tabBar!.currentTitle = value ? value.title : null;
   }
 
   /**
@@ -176,7 +176,7 @@ class TabPanel extends Widget {
    * Tabs can always be moved programmatically.
    */
   get tabsMovable(): boolean {
-    return this._tabBar.tabsMovable;
+    return this._tabBar!.tabsMovable;
   }
 
   /**
@@ -186,7 +186,7 @@ class TabPanel extends Widget {
    * Tabs can always be moved programmatically.
    */
   set tabsMovable(value: boolean) {
-    this._tabBar.tabsMovable = value;
+    this._tabBar!.tabsMovable = value;
   }
 
   /**
@@ -220,9 +220,9 @@ class TabPanel extends Widget {
     let orientation = Private.orientationFromPlacement(value);
 
     // Configure the tab bar for the placement.
-    this._tabBar.orientation = orientation;
-    this._tabBar.removeClass(`p-mod-${old}`);
-    this._tabBar.addClass(`p-mod-${value}`);
+    this._tabBar!.orientation = orientation;
+    this._tabBar!.removeClass(`p-mod-${old}`);
+    this._tabBar!.addClass(`p-mod-${value}`);
 
     // Update the layout direction.
     (this.layout as BoxLayout).direction = direction;
@@ -259,7 +259,7 @@ class TabPanel extends Widget {
    * This is a read-only property.
    */
   get widgets(): ISequence<Widget> {
-    return this._stackedPanel.widgets;
+    return this._stackedPanel!.widgets;
   }
 
   /**
@@ -290,8 +290,8 @@ class TabPanel extends Widget {
    */
   insertWidget(index: number, widget: Widget): void {
     if (widget !== this.currentWidget) widget.hide();
-    this._stackedPanel.insertWidget(index, widget);
-    this._tabBar.insertTab(index, widget.title);
+    this._stackedPanel!.insertWidget(index, widget);
+    this._tabBar!.insertTab(index, widget.title);
   }
 
   /**
@@ -325,14 +325,14 @@ class TabPanel extends Widget {
    * Handle the `tabMoved` signal from the tab bar.
    */
   private _onTabMoved(sender: TabBar, args: TabBar.ITabMovedArgs): void {
-    this._stackedPanel.insertWidget(args.toIndex, args.title.owner as Widget);
+    this._stackedPanel!.insertWidget(args.toIndex, args.title.owner as Widget);
   }
 
   /**
    * Handle the `widgetRemoved` signal from the stacked panel.
    */
   private _onWidgetRemoved(sender: StackedPanel, widget: Widget): void {
-    this._tabBar.removeTab(widget.title);
+    this._tabBar!.removeTab(widget.title);
   }
 
   private _tabBar: TabBar | null;

--- a/src/ui/tabpanel.ts
+++ b/src/ui/tabpanel.ts
@@ -110,8 +110,9 @@ class TabPanel extends Widget {
    * Dispose of the resources held by the widget.
    */
   dispose(): void {
-    this._tabBar = null;
-    this._stackedPanel = null;
+    // Do not type check these for disposed objects:
+    this._tabBar = null!;
+    this._stackedPanel = null!;
     super.dispose();
   }
 
@@ -135,7 +136,7 @@ class TabPanel extends Widget {
    * This will be `-1` if no tab is selected.
    */
   get currentIndex(): number {
-    return this._tabBar!.currentIndex;
+    return this._tabBar.currentIndex;
   }
 
   /**
@@ -145,7 +146,7 @@ class TabPanel extends Widget {
    * If the index is out of range, it will be set to `-1`.
    */
   set currentIndex(value: number) {
-    this._tabBar!.currentIndex = value;
+    this._tabBar.currentIndex = value;
   }
 
   /**
@@ -155,7 +156,7 @@ class TabPanel extends Widget {
    * This will be `null` if there is no selected tab.
    */
   get currentWidget(): Widget | null {
-    let title = this._tabBar!.currentTitle;
+    let title = this._tabBar.currentTitle;
     return title ? title.owner as Widget : null;
   }
 
@@ -166,7 +167,7 @@ class TabPanel extends Widget {
    * If the widget is not in the panel, it will be set to `null`.
    */
   set currentWidget(value: Widget | null) {
-    this._tabBar!.currentTitle = value ? value.title : null;
+    this._tabBar.currentTitle = value ? value.title : null;
   }
 
   /**
@@ -176,7 +177,7 @@ class TabPanel extends Widget {
    * Tabs can always be moved programmatically.
    */
   get tabsMovable(): boolean {
-    return this._tabBar!.tabsMovable;
+    return this._tabBar.tabsMovable;
   }
 
   /**
@@ -186,7 +187,7 @@ class TabPanel extends Widget {
    * Tabs can always be moved programmatically.
    */
   set tabsMovable(value: boolean) {
-    this._tabBar!.tabsMovable = value;
+    this._tabBar.tabsMovable = value;
   }
 
   /**
@@ -220,9 +221,9 @@ class TabPanel extends Widget {
     let orientation = Private.orientationFromPlacement(value);
 
     // Configure the tab bar for the placement.
-    this._tabBar!.orientation = orientation;
-    this._tabBar!.removeClass(`p-mod-${old}`);
-    this._tabBar!.addClass(`p-mod-${value}`);
+    this._tabBar.orientation = orientation;
+    this._tabBar.removeClass(`p-mod-${old}`);
+    this._tabBar.addClass(`p-mod-${value}`);
 
     // Update the layout direction.
     (this.layout as BoxLayout).direction = direction;
@@ -236,7 +237,7 @@ class TabPanel extends Widget {
    *
    * This is a read-only property.
    */
-  get tabBar(): TabBar | null {
+  get tabBar(): TabBar {
     return this._tabBar;
   }
 
@@ -248,7 +249,7 @@ class TabPanel extends Widget {
    *
    * This is a read-only property.
    */
-  get stackedPanel(): StackedPanel | null {
+  get stackedPanel(): StackedPanel {
     return this._stackedPanel;
   }
 
@@ -259,7 +260,7 @@ class TabPanel extends Widget {
    * This is a read-only property.
    */
   get widgets(): ISequence<Widget> {
-    return this._stackedPanel!.widgets;
+    return this._stackedPanel.widgets;
   }
 
   /**
@@ -290,8 +291,8 @@ class TabPanel extends Widget {
    */
   insertWidget(index: number, widget: Widget): void {
     if (widget !== this.currentWidget) widget.hide();
-    this._stackedPanel!.insertWidget(index, widget);
-    this._tabBar!.insertTab(index, widget.title);
+    this._stackedPanel.insertWidget(index, widget);
+    this._tabBar.insertTab(index, widget.title);
   }
 
   /**
@@ -325,18 +326,18 @@ class TabPanel extends Widget {
    * Handle the `tabMoved` signal from the tab bar.
    */
   private _onTabMoved(sender: TabBar, args: TabBar.ITabMovedArgs): void {
-    this._stackedPanel!.insertWidget(args.toIndex, args.title.owner as Widget);
+    this._stackedPanel.insertWidget(args.toIndex, args.title.owner as Widget);
   }
 
   /**
    * Handle the `widgetRemoved` signal from the stacked panel.
    */
   private _onWidgetRemoved(sender: StackedPanel, widget: Widget): void {
-    this._tabBar!.removeTab(widget.title);
+    this._tabBar.removeTab(widget.title);
   }
 
-  private _tabBar: TabBar | null;
-  private _stackedPanel: StackedPanel | null;
+  private _tabBar: TabBar;
+  private _stackedPanel: StackedPanel;
   private _tabPlacement: TabPanel.TabPlacement;
 }
 

--- a/src/ui/vdom.ts
+++ b/src/ui/vdom.ts
@@ -955,7 +955,7 @@ function realize(content: VNode): HTMLElement {
  * result in undefined rendering behavior.
  */
 export
-function render(content: VNode | VNode[], host: HTMLElement): void {
+function render(content: VNode | VNode[] | null, host: HTMLElement): void {
   Private.renderImpl(content, host);
 }
 
@@ -994,7 +994,7 @@ namespace Private {
    * The internal `render` entry point.
    */
   export
-  function renderImpl(content: VNode | VNode[], host: HTMLElement): void {
+  function renderImpl(content: VNode | VNode[] | null, host: HTMLElement): void {
     let oldContent = hostMap.get(host) || emptyArray;
     let newContent = asVNodeArray(content);
     hostMap.set(host, newContent);
@@ -1021,7 +1021,7 @@ namespace Private {
    *
    * Null content will be coerced to an empty array.
    */
-  function asVNodeArray(content: VNode | VNode[]): VNode[] {
+  function asVNodeArray(content: VNode | VNode[] | null): VNode[] {
     if (content instanceof Array) {
       return content as VNode[];
     }

--- a/src/ui/vdom.ts
+++ b/src/ui/vdom.ts
@@ -815,7 +815,7 @@ export function h(tag: string, first?: any): VNode {
  */
 export
 namespace h {
-  export type FactoryChild = (string | VNode) | Array<string | VNode>;
+  export type FactoryChild = (string | VNode | null) | Array<string | VNode | null>;
   export type Factory<T extends IVNodeAttrs> = (attrs?: T, ...children: FactoryChild[]) => VNode;
   export const a: Factory<IAnchorAttrs> = h.bind(void 0, 'a');
   export const abbr: Factory<IElementAttrs> = h.bind(void 0, 'abbr');

--- a/src/ui/vdom.ts
+++ b/src/ui/vdom.ts
@@ -765,7 +765,7 @@ export function h(tag: string, attrs?: IElementAttrs, ...children: h.FactoryChil
 export function h(tag: string, first?: any): VNode {
   // Setup the variables to hold the parsed data.
   let attrs: any;
-  let children: any[];
+  let children: any[] | undefined;
 
   // Parse the first variadic argument.
   if (first) {

--- a/src/ui/widget.ts
+++ b/src/ui/widget.ts
@@ -156,7 +156,7 @@ class Widget implements IDisposable, IMessageHandler {
    * #### Notes
    * This is a read-only property.
    */
-  get node(): HTMLElement {
+  get node(): HTMLElement | null {
     return this._node;
   }
 
@@ -197,7 +197,7 @@ class Widget implements IDisposable, IMessageHandler {
    * #### Notes
    * This will be `null` if the widget does not have a parent.
    */
-  get parent(): Widget {
+  get parent(): Widget | null {
     return this._parent;
   }
 
@@ -212,7 +212,7 @@ class Widget implements IDisposable, IMessageHandler {
    *
    * This is a no-op if there is no effective parent change.
    */
-  set parent(value: Widget) {
+  set parent(value: Widget | null) {
     value = value || null;
     if (this._parent === value) {
       return;
@@ -927,7 +927,7 @@ abstract class Layout implements IIterable<Widget>, IDisposable {
   /**
    * Get the parent widget of the layout.
    */
-  get parent(): Widget {
+  get parent(): Widget | null {
     return this._parent;
   }
 
@@ -938,7 +938,7 @@ abstract class Layout implements IIterable<Widget>, IDisposable {
    * This is set automatically when installing the layout on the parent
    * widget. The parent widget should not be set directly by user code.
    */
-  set parent(value: Widget) {
+  set parent(value: Widget | null) {
     if (!value) {
       throw new Error('Cannot set parent widget to null.');
     }

--- a/src/ui/widget.ts
+++ b/src/ui/widget.ts
@@ -164,14 +164,14 @@ class Widget implements IDisposable, IMessageHandler {
    * Get the id of the widget's DOM node.
    */
   get id(): string {
-    return this._node.id;
+    return this._node!.id;
   }
 
   /**
    * Set the id of the widget's DOM node.
    */
   set id(value: string) {
-    this._node.id = value;
+    this._node!.id = value;
   }
 
   /**
@@ -305,7 +305,7 @@ class Widget implements IDisposable, IMessageHandler {
    * @returns `true` if the node has the class, `false` otherwise.
    */
   hasClass(name: string): boolean {
-    return this._node.classList.contains(name);
+    return this._node!.classList.contains(name);
   }
 
   /**
@@ -319,7 +319,7 @@ class Widget implements IDisposable, IMessageHandler {
    * The class name must not contain whitespace.
    */
   addClass(name: string): void {
-    this._node.classList.add(name);
+    this._node!.classList.add(name);
   }
 
   /**
@@ -333,7 +333,7 @@ class Widget implements IDisposable, IMessageHandler {
    * The class name must not contain whitespace.
    */
   removeClass(name: string): void {
-    this._node.classList.remove(name);
+    this._node!.classList.remove(name);
   }
 
   /**
@@ -352,14 +352,14 @@ class Widget implements IDisposable, IMessageHandler {
    */
   toggleClass(name: string, force?: boolean): boolean {
     if (force === true) {
-      this._node.classList.add(name);
+      this._node!.classList.add(name);
       return true;
     }
     if (force === false) {
-      this._node.classList.remove(name);
+      this._node!.classList.remove(name);
       return false;
     }
-    return this._node.classList.toggle(name);
+    return this._node!.classList.toggle(name);
   }
 
   /**
@@ -727,13 +727,13 @@ namespace Widget {
     if (widget.parent) {
       throw new Error('Cannot attach child widget.');
     }
-    if (widget.isAttached || document.body.contains(widget.node)) {
+    if (widget.isAttached || document.body.contains(widget.node!)) {
       throw new Error('Widget already attached.');
     }
     if (!document.body.contains(host)) {
       throw new Error('Host not attached.');
     }
-    host.appendChild(widget.node);
+    host.appendChild(widget.node!);
     sendMessage(widget, WidgetMessage.AfterAttach);
   }
 
@@ -752,11 +752,11 @@ namespace Widget {
     if (widget.parent) {
       throw new Error('Cannot detach child widget.');
     }
-    if (!widget.isAttached || !document.body.contains(widget.node)) {
+    if (!widget.isAttached || !document.body.contains(widget.node!)) {
       throw new Error('Widget not attached.');
     }
     sendMessage(widget, WidgetMessage.BeforeDetach);
-    widget.node.parentNode.removeChild(widget.node);
+    widget.node!.parentNode.removeChild(widget.node!);
   }
 
   /**
@@ -769,7 +769,7 @@ namespace Widget {
    */
   export
   function prepareGeometry(widget: Widget): void {
-    widget.node.style.position = 'absolute';
+    widget.node!.style.position = 'absolute';
   }
 
   /**
@@ -782,7 +782,7 @@ namespace Widget {
    */
   export
   function resetGeometry(widget: Widget): void {
-    let style = widget.node.style;
+    let style = widget.node!.style;
     let rect = Private.rectProperty.get(widget)!;
     rect.top = NaN;
     rect.left = NaN;
@@ -820,7 +820,7 @@ namespace Widget {
   export
   function setGeometry(widget: Widget, left: number, top: number, width: number, height: number): void {
     let resized = false;
-    let style = widget.node.style;
+    let style = widget.node!.style;
     let rect = Private.rectProperty.get(widget)!;
     if (rect.top !== top) {
       rect.top = top;

--- a/src/ui/widget.ts
+++ b/src/ui/widget.ts
@@ -188,7 +188,7 @@ class Widget implements IDisposable, IMessageHandler {
    * This is a read-only property.
    */
   get title(): Title {
-    return Private.titleProperty.get(this);
+    return Private.titleProperty.get(this)!;
   }
 
   /**
@@ -236,7 +236,7 @@ class Widget implements IDisposable, IMessageHandler {
    * #### Notes
    * This will be `null` if the widget does not have a layout.
    */
-  get layout(): Layout {
+  get layout(): Layout | null {
     return this._layout;
   }
 
@@ -249,7 +249,7 @@ class Widget implements IDisposable, IMessageHandler {
    *
    * The layout is disposed automatically when the widget is disposed.
    */
-  set layout(value: Layout) {
+  set layout(value: Layout | null) {
     value = value || null;
     if (this._layout === value) {
       return;
@@ -260,11 +260,12 @@ class Widget implements IDisposable, IMessageHandler {
     if (this._layout) {
       throw new Error('Cannot change widget layout.');
     }
-    if (value.parent) {
+    // Know that value is not null from above checks
+    if (value!.parent) {
       throw new Error('Cannot change layout parent.');
     }
     this._layout = value;
-    value.parent = this;
+    value!.parent = this;
     sendMessage(this, WidgetMessage.LayoutChanged);
   }
 
@@ -289,7 +290,7 @@ class Widget implements IDisposable, IMessageHandler {
    *
    * @returns `true` if the widget is a descendant, `false` otherwise.
    */
-  contains(widget: Widget): boolean {
+  contains(widget: Widget | null): boolean {
     for (; widget; widget = widget._parent) {
       if (widget === this) return true;
     }
@@ -677,9 +678,9 @@ class Widget implements IDisposable, IMessageHandler {
   protected onChildRemoved(msg: ChildMessage): void { }
 
   private _flags = 0;
-  private _node: HTMLElement;
-  private _layout: Layout = null;
-  private _parent: Widget = null;
+  private _node: HTMLElement | null;
+  private _layout: Layout | null = null;
+  private _parent: Widget | null = null;
 }
 
 
@@ -782,7 +783,7 @@ namespace Widget {
   export
   function resetGeometry(widget: Widget): void {
     let style = widget.node.style;
-    let rect = Private.rectProperty.get(widget);
+    let rect = Private.rectProperty.get(widget)!;
     rect.top = NaN;
     rect.left = NaN;
     rect.width = NaN;
@@ -820,7 +821,7 @@ namespace Widget {
   function setGeometry(widget: Widget, left: number, top: number, width: number, height: number): void {
     let resized = false;
     let style = widget.node.style;
-    let rect = Private.rectProperty.get(widget);
+    let rect = Private.rectProperty.get(widget)!;
     if (rect.top !== top) {
       rect.top = top;
       style.top = `${top}px`;
@@ -1116,7 +1117,7 @@ abstract class Layout implements IIterable<Widget>, IDisposable {
   protected onChildHidden(msg: ChildMessage): void { }
 
   private _disposed = false;
-  private _parent: Widget = null;
+  private _parent: Widget | null = null;
 }
 
 

--- a/src/ui/widget.ts
+++ b/src/ui/widget.ts
@@ -99,7 +99,7 @@ class Widget implements IDisposable, IMessageHandler {
     clearPropertyData(this);
 
     // Clear the reference to the DOM node.
-    this._node = null;
+    this._node = null!;  // Do not type check null for disposed
   }
 
   /**
@@ -156,7 +156,7 @@ class Widget implements IDisposable, IMessageHandler {
    * #### Notes
    * This is a read-only property.
    */
-  get node(): HTMLElement | null {
+  get node(): HTMLElement {
     return this._node;
   }
 
@@ -164,14 +164,14 @@ class Widget implements IDisposable, IMessageHandler {
    * Get the id of the widget's DOM node.
    */
   get id(): string {
-    return this._node!.id;
+    return this._node.id;
   }
 
   /**
    * Set the id of the widget's DOM node.
    */
   set id(value: string) {
-    this._node!.id = value;
+    this._node.id = value;
   }
 
   /**
@@ -305,7 +305,7 @@ class Widget implements IDisposable, IMessageHandler {
    * @returns `true` if the node has the class, `false` otherwise.
    */
   hasClass(name: string): boolean {
-    return this._node!.classList.contains(name);
+    return this._node.classList.contains(name);
   }
 
   /**
@@ -319,7 +319,7 @@ class Widget implements IDisposable, IMessageHandler {
    * The class name must not contain whitespace.
    */
   addClass(name: string): void {
-    this._node!.classList.add(name);
+    this._node.classList.add(name);
   }
 
   /**
@@ -333,7 +333,7 @@ class Widget implements IDisposable, IMessageHandler {
    * The class name must not contain whitespace.
    */
   removeClass(name: string): void {
-    this._node!.classList.remove(name);
+    this._node.classList.remove(name);
   }
 
   /**
@@ -352,14 +352,14 @@ class Widget implements IDisposable, IMessageHandler {
    */
   toggleClass(name: string, force?: boolean): boolean {
     if (force === true) {
-      this._node!.classList.add(name);
+      this._node.classList.add(name);
       return true;
     }
     if (force === false) {
-      this._node!.classList.remove(name);
+      this._node.classList.remove(name);
       return false;
     }
-    return this._node!.classList.toggle(name);
+    return this._node.classList.toggle(name);
   }
 
   /**
@@ -678,7 +678,7 @@ class Widget implements IDisposable, IMessageHandler {
   protected onChildRemoved(msg: ChildMessage): void { }
 
   private _flags = 0;
-  private _node: HTMLElement | null;
+  private _node: HTMLElement;
   private _layout: Layout | null = null;
   private _parent: Widget | null = null;
 }
@@ -727,13 +727,13 @@ namespace Widget {
     if (widget.parent) {
       throw new Error('Cannot attach child widget.');
     }
-    if (widget.isAttached || document.body.contains(widget.node!)) {
+    if (widget.isAttached || document.body.contains(widget.node)) {
       throw new Error('Widget already attached.');
     }
     if (!document.body.contains(host)) {
       throw new Error('Host not attached.');
     }
-    host.appendChild(widget.node!);
+    host.appendChild(widget.node);
     sendMessage(widget, WidgetMessage.AfterAttach);
   }
 
@@ -752,11 +752,11 @@ namespace Widget {
     if (widget.parent) {
       throw new Error('Cannot detach child widget.');
     }
-    if (!widget.isAttached || !document.body.contains(widget.node!)) {
+    if (!widget.isAttached || !document.body.contains(widget.node)) {
       throw new Error('Widget not attached.');
     }
     sendMessage(widget, WidgetMessage.BeforeDetach);
-    widget.node!.parentNode.removeChild(widget.node!);
+    widget.node.parentNode.removeChild(widget.node);
   }
 
   /**
@@ -769,7 +769,7 @@ namespace Widget {
    */
   export
   function prepareGeometry(widget: Widget): void {
-    widget.node!.style.position = 'absolute';
+    widget.node.style.position = 'absolute';
   }
 
   /**
@@ -782,7 +782,7 @@ namespace Widget {
    */
   export
   function resetGeometry(widget: Widget): void {
-    let style = widget.node!.style;
+    let style = widget.node.style;
     let rect = Private.rectProperty.get(widget)!;
     rect.top = NaN;
     rect.left = NaN;
@@ -820,7 +820,7 @@ namespace Widget {
   export
   function setGeometry(widget: Widget, left: number, top: number, width: number, height: number): void {
     let resized = false;
-    let style = widget.node!.style;
+    let style = widget.node.style;
     let rect = Private.rectProperty.get(widget)!;
     if (rect.top !== top) {
       rect.top = top;

--- a/test/src/algorithm/json.spec.ts
+++ b/test/src/algorithm/json.spec.ts
@@ -24,7 +24,7 @@ describe('algorithm/json', () => {
     });
 
     it('should return `false` if the value is not a primitive or `null`', () => {
-      expect(isPrimitive(void 0)).to.be(false);
+      expect(isPrimitive(void 0 as any)).to.be(false);
       expect(isPrimitive([])).to.be(false);
       expect(isPrimitive({})).to.be(false);
     });
@@ -65,7 +65,7 @@ describe('algorithm/json', () => {
       expect(deepEqual({a: []}, {a: [1]})).to.be(false);
       expect(deepEqual([1], [1, 2])).to.be(false);
       expect(deepEqual(null, [1, 2])).to.be(false);
-      expect(deepEqual(void 0, [])).to.be(false);
+      expect(deepEqual(void 0 as any, [])).to.be(false);
       expect(deepEqual([1], {})).to.be(false);
       expect(deepEqual([1], [2])).to.be(false);
       expect(deepEqual({}, { a: 1 })).to.be(false);

--- a/test/src/algorithm/searching.spec.ts
+++ b/test/src/algorithm/searching.spec.ts
@@ -328,9 +328,9 @@ describe('algorithm/searching', () => {
     describe('sumOfSquares()', () => {
 
       it('should score the match using the sum of squared distances', () => {
-        let r1 = StringSearch.sumOfSquares('Foo Bar Baz', 'Faa');
-        let r2 = StringSearch.sumOfSquares('Foo Bar Baz', 'oBz');
-        let r3 = StringSearch.sumOfSquares('Foo Bar Baz', 'r B');
+        let r1 = StringSearch.sumOfSquares('Foo Bar Baz', 'Faa')!;
+        let r2 = StringSearch.sumOfSquares('Foo Bar Baz', 'oBz')!;
+        let r3 = StringSearch.sumOfSquares('Foo Bar Baz', 'r B')!;
         expect(r1.score).to.be(106);
         expect(r1.indices).to.eql([0, 5, 9]);
         expect(r2.score).to.be(117);
@@ -353,9 +353,9 @@ describe('algorithm/searching', () => {
     describe('highlight()', () => {
 
       it('should interpolate text with <mark> tags', () => {
-        let r1 = StringSearch.sumOfSquares('Foo Bar Baz', 'Faa');
-        let r2 = StringSearch.sumOfSquares('Foo Bar Baz', 'oBz');
-        let r3 = StringSearch.sumOfSquares('Foo Bar Baz', 'r B');
+        let r1 = StringSearch.sumOfSquares('Foo Bar Baz', 'Faa')!;
+        let r2 = StringSearch.sumOfSquares('Foo Bar Baz', 'oBz')!;
+        let r3 = StringSearch.sumOfSquares('Foo Bar Baz', 'r B')!;
         let h1 = StringSearch.highlight('Foo Bar Baz', r1.indices);
         let h2 = StringSearch.highlight('Foo Bar Baz', r2.indices);
         let h3 = StringSearch.highlight('Foo Bar Baz', r3.indices);

--- a/test/src/core/properties.spec.ts
+++ b/test/src/core/properties.spec.ts
@@ -418,8 +418,8 @@ describe('core/properties', () => {
       });
 
       it('should use the default value as old value if value is not yet set', () => {
-        let oldval: number;
-        let newval: number;
+        let oldval: number | undefined;
+        let newval: number | undefined;
         let coerce = (m: Model, v: number) => Math.max(20, v);
         let changed = (m: Model, o: number, n: number) => { oldval = o; newval = n; };
         let p = new AttachedProperty<Model, number>({ name: 'p', value: 0, coerce, changed });
@@ -430,8 +430,8 @@ describe('core/properties', () => {
       });
 
       it('should use the default factory for old value if value is not yet set', () => {
-        let oldval: number;
-        let newval: number;
+        let oldval: number | undefined;
+        let newval: number | undefined;
         let create = () => 12;
         let coerce = (m: Model, v: number) => Math.max(20, v);
         let changed = (m: Model, o: number, n: number) => { oldval = o; newval = n; };
@@ -443,8 +443,8 @@ describe('core/properties', () => {
       });
 
       it('should prefer the default factory over default value', () => {
-        let oldval: number;
-        let newval: number;
+        let oldval: number | undefined;
+        let newval: number | undefined;
         let create = () => 12;
         let coerce = (m: Model, v: number) => Math.max(20, v);
         let changed = (m: Model, o: number, n: number) => { oldval = o; newval = n; };

--- a/test/src/core/signaling.spec.ts
+++ b/test/src/core/signaling.spec.ts
@@ -44,7 +44,7 @@ class TestHandler {
 
   twoValue = 0;
 
-  twoSender: TestObject = null;
+  twoSender: TestObject | null = null;
 
   onOne(): void {
     this.oneCount++;
@@ -283,7 +283,7 @@ describe('core/signaling', () => {
 
     it('should define a read-only property', () => {
       let obj = new TestObject();
-      expect(() => { obj.one = null; }).to.throwError();
+      expect(() => { obj.one = null!; }).to.throwError();
     });
 
   });

--- a/test/src/dom/dragdrop.spec.ts
+++ b/test/src/dom/dragdrop.spec.ts
@@ -346,7 +346,7 @@ describe('dom/dragdrop', () => {
           let child0 = panel.widgets.at(0) as DropTarget;
           let rect = child0.node.getBoundingClientRect();
           simulate(child0.node, 'mousemove', { clientX: rect.left + 1, clientY: rect.top + 1 } );
-          let image = drag.dragImage;
+          let image = drag.dragImage!;
           expect(image.style.top).to.be(`${rect.top + 1}px`);
           expect(image.style.left).to.be(`${rect.left + 1}px`);
         });
@@ -442,7 +442,7 @@ describe('dom/dragdrop', () => {
         });
 
         it('should detach the drag image', () => {
-          let image = drag.dragImage;
+          let image = drag.dragImage!;
           let child0 = panel.widgets.at(0) as DropTarget;
           let rect = child0.node.getBoundingClientRect();
           simulate(child0.node, 'mouseup', { clientX: rect.left + 1, clientY: rect.top + 1 } );

--- a/test/src/dom/query.spec.ts
+++ b/test/src/dom/query.spec.ts
@@ -85,9 +85,9 @@ describe('dom/query', () => {
 
     afterEach(() => {
       document.body.removeChild(area);
-      area = null;
-      elemA = null;
-      elemB = null;
+      area = null!;
+      elemA = null!;
+      elemB = null!;
     });
 
     it('should do nothing if the element covers the viewport', () => {

--- a/test/src/tsconfig.json
+++ b/test/src/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "ES5",
-    "outDir": "../build"
+    "outDir": "../build",
+    "strictNullChecks": true
   }
 }

--- a/test/src/ui/commandpalette.spec.ts
+++ b/test/src/ui/commandpalette.spec.ts
@@ -189,7 +189,7 @@ describe('ui/commandpalette', () => {
 
         expect(node).to.be.ok();
         expect(shortcut).to.be.ok();
-        expect(shortcut.textContent.length).to.be.greaterThan(0);
+        expect(shortcut.textContent!.length).to.be.greaterThan(0);
         expect(palette.items.length).to.be(1);
         expect(palette.items.at(0).command).to.be('test');
       });
@@ -398,7 +398,7 @@ describe('ui/commandpalette', () => {
               command: 'test'
             });
             let item = palette.addItem({ command: 'test' });
-            expect(item.keyBinding.keys).to.eql(['Ctrl A']);
+            expect(item.keyBinding!.keys).to.eql(['Ctrl A']);
           });
 
           it('should be read-only', () => {

--- a/test/src/ui/keymap.spec.ts
+++ b/test/src/ui/keymap.spec.ts
@@ -66,15 +66,15 @@ describe('ui/keymap', () => {
       it('should be set from instantiation options', () => {
         let options = { keys: ['Ctrl A'], selector: 'body', command: 'test' };
         keymap.addBinding(options);
-        let binding = keymap.findBinding('test', null);
+        let binding = keymap.findBinding('test', null)!;
         expect(binding.keys).to.eql(['Ctrl A']);
       });
 
       it('should be read only', () => {
         let options = { keys: ['Ctrl A'], selector: 'body', command: 'test' };
         keymap.addBinding(options);
-        let binding = keymap.findBinding('test', null);
-        expect(() => { binding.keys = null; }).to.throwError();
+        let binding = keymap.findBinding('test', null)!;
+        expect(() => { binding.keys = null!; }).to.throwError();
       });
 
     });
@@ -84,15 +84,15 @@ describe('ui/keymap', () => {
       it('should be set from instantiation options', () => {
         let options = { keys: ['Ctrl A'], selector: 'body', command: 'test' };
         keymap.addBinding(options);
-        let binding = keymap.findBinding('test', null);
+        let binding = keymap.findBinding('test', null)!;
         expect(binding.selector).to.be('body');
       });
 
       it('should be read only', () => {
         let options = { keys: ['Ctrl A'], selector: 'body', command: 'test' };
         keymap.addBinding(options);
-        let binding = keymap.findBinding('test', null);
-        expect(() => { binding.selector = null; }).to.throwError();
+        let binding = keymap.findBinding('test', null)!;
+        expect(() => { binding.selector = null!; }).to.throwError();
       });
 
     });
@@ -102,15 +102,15 @@ describe('ui/keymap', () => {
       it('should be set from instantiation options', () => {
         let options = { keys: ['Ctrl A'], selector: 'body', command: 'test' };
         keymap.addBinding(options);
-        let binding = keymap.findBinding('test', null);
+        let binding = keymap.findBinding('test', null)!;
         expect(binding.command).to.be('test');
       });
 
       it('should be read only', () => {
         let options = { keys: ['Ctrl A'], selector: 'body', command: 'test' };
         keymap.addBinding(options);
-        let binding = keymap.findBinding('test', null);
-        expect(() => { binding.command = null; }).to.throwError();
+        let binding = keymap.findBinding('test', null)!;
+        expect(() => { binding.command = null!; }).to.throwError();
       });
 
     });
@@ -125,14 +125,14 @@ describe('ui/keymap', () => {
           args: { foo: 'bar', baz: 'qux' } as JSONObject
         };
         keymap.addBinding(options);
-        let binding = keymap.findBinding('test', options.args);
+        let binding = keymap.findBinding('test', options.args)!;
         expect(binding.args).to.eql(options.args);
       });
 
       it('should be read only', () => {
         let options = { keys: ['Ctrl A'], selector: 'body', command: 'test' };
         keymap.addBinding(options);
-        let binding = keymap.findBinding('test', null);
+        let binding = keymap.findBinding('test', null)!;
         expect(() => { binding.args = null; }).to.throwError();
       });
 
@@ -299,7 +299,7 @@ describe('ui/keymap', () => {
         let a1: JSONObject = { 'foo': 'bar' };
         let a2: JSONObject = { 'bar': 'baz' };
         let a3: JSONObject = { 'baz': 'qux' };
-        let a4: JSONObject = null;
+        let a4 = null;
         let b1 = keymap.addBinding({
           keys: ['Ctrl ;'],
           selector: '.b1',
@@ -324,10 +324,10 @@ describe('ui/keymap', () => {
           command: 'c2',
           args: a4
         });
-        expect(keymap.findBinding('c1', a1).selector).to.be('.b1');
-        expect(keymap.findBinding('c1', a2).selector).to.be('.b2');
-        expect(keymap.findBinding('c1', a3).selector).to.be('.b3');
-        expect(keymap.findBinding('c2', a4).selector).to.be('.b4');
+        expect(keymap.findBinding('c1', a1)!.selector).to.be('.b1');
+        expect(keymap.findBinding('c1', a2)!.selector).to.be('.b2');
+        expect(keymap.findBinding('c1', a3)!.selector).to.be('.b3');
+        expect(keymap.findBinding('c2', a4)!.selector).to.be('.b4');
         b1.dispose();
         b2.dispose();
         b3.dispose();

--- a/test/src/ui/menu.spec.ts
+++ b/test/src/ui/menu.spec.ts
@@ -480,7 +480,7 @@ describe('ui/menu', () => {
         };
         let disposable = keymap.addBinding(binding);
         let item = menu.addItem({ command: 'test' });
-        expect(item.keyBinding.keys).to.eql(['A']);
+        expect(item.keyBinding!.keys).to.eql(['A']);
         disposable.dispose();
       });
 

--- a/test/src/ui/menubar.spec.ts
+++ b/test/src/ui/menubar.spec.ts
@@ -322,7 +322,7 @@ describe('ui/menubar', () => {
         bar.activeMenu = menu;
         bar.openActiveMenu();
         expect(menu.isAttached).to.be(true);
-        expect(menu.activeItem.command).to.be(item.command);
+        expect(menu.activeItem!.command).to.be(item.command);
         bar.dispose();
       });
 
@@ -508,7 +508,7 @@ describe('ui/menubar', () => {
 
     describe('#handleEvent()', () => {
 
-      let bar: MenuBar = null;
+      let bar: MenuBar;
 
       beforeEach(() => {
         bar = createMenuBar();
@@ -516,30 +516,31 @@ describe('ui/menubar', () => {
 
       afterEach(() => {
         bar.dispose();
+        bar = null!;
       });
 
       context('keydown', () => {
 
         it('should open the active menu on Enter', () => {
-          let menu = bar.activeMenu;
+          let menu = bar.activeMenu!;
           simulate(bar.node, 'keydown', { keyCode: 13 });
           expect(menu.isAttached).to.be(true);
         });
 
         it('should open the active menu on Up Arrow', () => {
-          let menu = bar.activeMenu;
+          let menu = bar.activeMenu!;
           simulate(bar.node, 'keydown', { keyCode: 38 });
           expect(menu.isAttached).to.be(true);
         });
 
         it('should open the active menu on Down Arrow', () => {
-          let menu = bar.activeMenu;
+          let menu = bar.activeMenu!;
           simulate(bar.node, 'keydown', { keyCode: 40 });
           expect(menu.isAttached).to.be(true);
         });
 
         it('should close the active menu on Escape', () => {
-          let menu = bar.activeMenu;
+          let menu = bar.activeMenu!;
           bar.openActiveMenu();
           simulate(bar.node, 'keydown', { keyCode: 27 });
           expect(menu.isAttached).to.be(false);
@@ -566,7 +567,7 @@ describe('ui/menubar', () => {
         it('should open the menu matching a mnemonic', () => {
           simulate(bar.node, 'keydown', { keyCode: 97 });  // '1';
           expect(bar.activeIndex).to.be(1);
-          let menu = bar.activeMenu;
+          let menu = bar.activeMenu!;
           expect(menu.isAttached).to.be(true);
         });
 
@@ -574,7 +575,7 @@ describe('ui/menubar', () => {
           bar.activeIndex = 1;
           simulate(bar.node, 'keydown', { keyCode: 77 });  // 'M';
           expect(bar.activeIndex).to.be(1);
-          let menu = bar.activeMenu;
+          let menu = bar.activeMenu!;
           expect(menu.isAttached).to.be(false);
         });
 
@@ -585,7 +586,7 @@ describe('ui/menubar', () => {
           bar.addMenu(menu);
           simulate(bar.node, 'keydown', { keyCode: 97 });  // '1';
           expect(bar.activeIndex).to.be(1);
-          menu = bar.activeMenu;
+          menu = bar.activeMenu!;
           expect(menu.isAttached).to.be(false);
         });
 
@@ -596,7 +597,7 @@ describe('ui/menubar', () => {
           bar.addMenu(new Menu({ commands, keymap }));
           simulate(bar.node, 'keydown', { keyCode: 84 });  // 'T';
           expect(bar.activeIndex).to.be(3);
-          menu = bar.activeMenu;
+          menu = bar.activeMenu!;
           expect(menu.isAttached).to.be(false);
         });
 
@@ -612,7 +613,7 @@ describe('ui/menubar', () => {
 
         it('should close an open menu if the press was not on an item', () => {
           bar.openActiveMenu();
-          let menu = bar.activeMenu;
+          let menu = bar.activeMenu!;
           simulate(bar.node, 'mousedown');
           expect(bar.activeIndex).to.be(-1);
           expect(menu.isAttached).to.be(false);
@@ -620,7 +621,7 @@ describe('ui/menubar', () => {
 
         it('should close an active menu', () => {
           bar.openActiveMenu();
-          let menu = bar.activeMenu;
+          let menu = bar.activeMenu!;
           let node = bar.node.getElementsByClassName('p-MenuBar-item')[0] as HTMLElement;
           let rect = node.getBoundingClientRect();
           simulate(bar.node, 'mousedown', { clientX: rect.left, clientY: rect.top });
@@ -629,7 +630,7 @@ describe('ui/menubar', () => {
         });
 
         it('should open an active menu', () => {
-          let menu = bar.activeMenu;
+          let menu = bar.activeMenu!;
           let node = bar.node.getElementsByClassName('p-MenuBar-item')[0] as HTMLElement;
           let rect = node.getBoundingClientRect();
           simulate(bar.node, 'mousedown', { clientX: rect.left, clientY: rect.top });
@@ -639,7 +640,7 @@ describe('ui/menubar', () => {
 
         it('should not close an active menu if not a left mouse press', () => {
           bar.openActiveMenu();
-          let menu = bar.activeMenu;
+          let menu = bar.activeMenu!;
           let node = bar.node.getElementsByClassName('p-MenuBar-item')[0] as HTMLElement;
           let rect = node.getBoundingClientRect();
           simulate(bar.node, 'mousedown', { button: 1, clientX: rect.left, clientY: rect.top });
@@ -653,18 +654,18 @@ describe('ui/menubar', () => {
 
         it('should open a new menu if a menu is already open', () => {
           bar.openActiveMenu();
-          let menu = bar.activeMenu;
+          let menu = bar.activeMenu!;
           let node = bar.node.getElementsByClassName('p-MenuBar-item')[1] as HTMLElement;
           let rect = node.getBoundingClientRect();
           simulate(node, 'mousemove', { clientX: rect.left + 1, clientY: rect.top });
           expect(bar.activeIndex).to.be(1);
           expect(menu.isAttached).to.be(false);
-          expect(bar.activeMenu.isAttached).to.be(true);
+          expect(bar.activeMenu!.isAttached).to.be(true);
         });
 
         it('should be a no-op if the active index will not change', () => {
           bar.openActiveMenu();
-          let menu = bar.activeMenu;
+          let menu = bar.activeMenu!;
           let node = bar.node.getElementsByClassName('p-MenuBar-item')[0] as HTMLElement;
           let rect = node.getBoundingClientRect();
           simulate(bar.node, 'mousemove', { clientX: rect.left, clientY: rect.top + 1 });
@@ -674,7 +675,7 @@ describe('ui/menubar', () => {
 
         it('should be a no-op if the mouse is not over an item and there is a menu open', () => {
           bar.openActiveMenu();
-          let menu = bar.activeMenu;
+          let menu = bar.activeMenu!;
           simulate(bar.node, 'mousemove');
           expect(bar.activeIndex).to.be(0);
           expect(menu.isAttached).to.be(true);
@@ -691,7 +692,7 @@ describe('ui/menubar', () => {
 
         it('should be a no-op if there is an open menu', () => {
           bar.openActiveMenu();
-          let menu = bar.activeMenu;
+          let menu = bar.activeMenu!;
           simulate(bar.node, 'mouseleave');
           expect(bar.activeIndex).to.be(0);
           expect(menu.isAttached).to.be(true);
@@ -770,7 +771,7 @@ describe('ui/menubar', () => {
       it('should activate the next menu', () => {
         let bar = createMenuBar();
         bar.openActiveMenu();
-        bar.activeMenu.menuRequested.emit('next');
+        bar.activeMenu!.menuRequested.emit('next');
         expect(bar.activeIndex).to.be(1);
         bar.dispose();
       });
@@ -778,14 +779,14 @@ describe('ui/menubar', () => {
       it('should activate the previous menu', () => {
         let bar = createMenuBar();
         bar.openActiveMenu();
-        bar.activeMenu.menuRequested.emit('previous');
+        bar.activeMenu!.menuRequested.emit('previous');
         expect(bar.activeIndex).to.be(2);
         bar.dispose();
       });
 
       it('should be a no-op if the sender is not the open menu', () => {
         let bar = createMenuBar();
-        bar.activeMenu.menuRequested.emit('next');
+        bar.activeMenu!.menuRequested.emit('next');
         expect(bar.activeIndex).to.be(0);
         bar.dispose();
       });

--- a/test/src/ui/widget.spec.ts
+++ b/test/src/ui/widget.spec.ts
@@ -121,7 +121,7 @@ class LogLayout extends Layout {
 
   dispose(): void {
     each(this._widgets, w => w.dispose());
-    this._widgets = null;
+    this._widgets = null!;
     super.dispose();
   }
 
@@ -1689,12 +1689,12 @@ describe('ui/widget', () => {
         let parent = new Widget();
         parent.layout = layout;
         let iter = layout.iter();
-        let child = iter.next();
+        let child = iter.next()!;
         child.hide();
         sendMessage(parent, WidgetMessage.AfterShow);
         expect(layout.methods.indexOf('onAfterShow')).to.not.be(-1);
         expect(child.methods.indexOf('onAfterShow')).to.be(-1);
-        child = iter.next();
+        child = iter.next()!;
         expect(child.methods.indexOf('onAfterShow')).to.not.be(-1);
       });
 
@@ -1715,12 +1715,12 @@ describe('ui/widget', () => {
         let parent = new Widget();
         parent.layout = layout;
         let iter = layout.iter();
-        let child = iter.next();
+        let child = iter.next()!;
         child.hide();
         sendMessage(parent, WidgetMessage.BeforeHide);
         expect(layout.methods.indexOf('onBeforeHide')).to.not.be(-1);
         expect(child.methods.indexOf('onBeforeHide')).to.be(-1);
-        child = iter.next();
+        child = iter.next()!;
         expect(child.methods.indexOf('onBeforeHide')).to.not.be(-1);
       });
 


### PR DESCRIPTION
Switch typescript code to use strict null checks. The PR is split into logically grouped commits, to ease review. The commit with "safe" typings are the straight-forward changes, which should not be controversial.

The other major change, is the addition of a ton of non-null assertion operators (`!` postfix), specifically on `Widget.parent` and `Widget.node` and other properties that become null only after the object is disposed, that is, things that are safe to assume is not null for many scenarios. An alternative solution to this is to hide these nulls from the compiler (do a non-null assertion in the property getter), which would then selectively turn off strict null checks for these variables.
