### PR TITLE
Quickfix for dependents with strict null checks

### DIFF
--- a/src/algorithm/json.ts
+++ b/src/algorithm/json.ts
@@ -11,7 +11,7 @@
  * A type alias for a JSON primitive.
  */
 export
-type JSONPrimitive = boolean | number | string;
+type JSONPrimitive = boolean | number | string | null;
 
 
 /**
@@ -25,7 +25,7 @@ type JSONValue = JSONPrimitive | JSONObject | JSONArray;
  * A type definition for a JSON object.
  */
 export
-interface JSONObject { [key: string]: JSONValue; }
+interface JSONObject { [key: string]: JSONValue | undefined; }
 
 
 /**


### PR DESCRIPTION
These changes will prevent downstream compiler errors in dependencies that use strict null checks, without having any effect on the current phosphor behavior.

Proposed as a quickfix since discussion in #150 suggests that full support for strict null checks are a bit away.