### PR TITLE
Add workaround for typedoc

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -9,5 +9,6 @@
     "outDir": "../lib",
     "lib": ["dom", "es5", "es2015.collection", "es2015.promise"],
     "types": []
-  }
+  },
+  "exclude": ["typedoc.d.ts"]
 }

--- a/src/typedoc.d.ts
+++ b/src/typedoc.d.ts
@@ -1,0 +1,17 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2016, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+/*
+ * TODO: remove this file and the excludes entry in tsconfig.json
+ * after typedoc understands the lib compiler option and @types packages.
+ */
+
+/// <reference path="../node_modules/typescript/lib/lib.es2015.promise.d.ts"/>
+/// <reference path="../node_modules/typescript/lib/lib.dom.d.ts"/>
+/// <reference path="../node_modules/typescript/lib/lib.es5.d.ts"/>
+/// <reference path="../node_modules/typescript/lib/lib.es2015.collection.d.ts"/>


### PR DESCRIPTION
This is the workaround we are using in JupyterLab.

Fixes #157.