### PR TITLE
Fix #201: Disallow dropping a DockPanel's parent widget as a new child.

### DIFF
--- a/@phosphor/widgets/src/dockpanel.ts
+++ b/@phosphor/widgets/src/dockpanel.ts
@@ -374,9 +374,9 @@ class DockPanel extends Widget {
       return;
     }
 
-    // Bail if the factory does not produce a widget.
+    // Bail if the factory does not produce a widget or it contains this panel.
     let widget = factory();
-    if (!(widget instanceof Widget)) {
+    if (!(widget instanceof Widget) || widget.node.contains(this.node)) {
       event.dropAction = 'none';
       return;
     }


### PR DESCRIPTION
The DockPanel should check whether a dropped widget contains the panel itself, before trying to add it as a child.
