### PR TITLE
Fix initial value for menu child index

### DIFF
--- a/@phosphor/widgets/src/menu.ts
+++ b/@phosphor/widgets/src/menu.ts
@@ -894,7 +894,7 @@ class Menu extends Widget {
     }
   }
 
-  private _childIndex = 1;
+  private _childIndex = -1;
   private _activeIndex = -1;
   private _openTimerID = 0;
   private _closeTimerID = 0;


### PR DESCRIPTION
This was preventing submenus at index 1 from opening.  cf https://github.com/jupyterlab/jupyterlab/issues/1799.