### PR TITLE
Feature save restore layout

### DIFF
--- a/examples/example-dockpanel/src/index.ts
+++ b/examples/example-dockpanel/src/index.ts
@@ -314,6 +314,36 @@ function main(): void {
   dock.addWidget(b2, { mode: 'split-right', ref: y1 });
   dock.id = 'dock';
 
+  let savedLayouts: DockPanel.ILayoutConfig[] = [];
+
+  commands.addCommand('save-dock-layout', {
+    label: 'Save Layout',
+    caption: 'Save the current dock layout',
+    execute: () => {
+      savedLayouts.push(dock.saveLayout());
+      palette.addItem({
+        command: 'restore-dock-layout',
+        category: 'Dock Layout',
+        args: { index: savedLayouts.length - 1 }
+      });
+    }
+  });
+
+  commands.addCommand('restore-dock-layout', {
+    label: args => {
+      return `Restore Layout ${args.index as number}`;
+    },
+    execute: args => {
+      dock.restoreLayout(savedLayouts[args.index as number]);
+    }
+  });
+
+  palette.addItem({
+    command: 'save-dock-layout',
+    category: 'Dock Layout',
+    rank: 0
+  });
+
   BoxPanel.setStretch(dock, 1);
 
   let main = new BoxPanel({ direction: 'left-to-right', spacing: 0 });

--- a/packages/widgets/src/docklayout.ts
+++ b/packages/widgets/src/docklayout.ts
@@ -295,6 +295,11 @@ class DockLayout extends Layout {
 
     // Post a fit request to the parent.
     this.parent.fit();
+
+    // Flush the message loop on IE and Edge to prevent flicker.
+    if (Platform.IS_EDGE || Platform.IS_IE) {
+      MessageLoop.flush();
+    }
   }
 
   /**

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -191,6 +191,34 @@ class DockPanel extends Widget {
   }
 
   /**
+   * Save the current layout configuration of the dock panel.
+   *
+   * @returns A new snapshot of the current layout configuration.
+   *
+   * #### Notes
+   * The return value can be provided to the `restoreLayout` method
+   * in order to restore the layout to its current configuration.
+   */
+  saveLayout(): DockPanel.ILayoutConfig {
+    return (this.layout as DockLayout).saveLayout();
+  }
+
+  /**
+   * Restore the layout to a previously saved configuration.
+   *
+   * @param config - The layout configuration to restore.
+   *
+   * @throws An error if the config is invalid.
+   *
+   * #### Notes
+   * Widgets which currently belong to the layout but which are not
+   * contained in the config will be unparented.
+   */
+  restoreLayout(config: DockPanel.ILayoutConfig): void {
+    (this.layout as DockLayout).restoreLayout(config);
+  }
+
+  /**
    * Add a widget to the dock panel.
    *
    * @param widget - The widget to add to the dock panel.
@@ -790,6 +818,12 @@ namespace DockPanel {
      */
     spacing?: number;
   }
+
+  /**
+   * A type alias for a layout configuration object.
+   */
+  export
+  type ILayoutConfig = DockLayout.ILayoutConfig;
 
   /**
    * A type alias for the supported insertion modes.


### PR DESCRIPTION
This implements save/restore dock layout. Fixes #33.

The only thing I'm not sure about is the top level layout object. Currently it's a simple object with one `main` property which holds the layout config for the main area. The thinking here is that if we expand dock layout support to maximized panels and/or tear-out panels, then we'll need space to grow extra properties. However, @ellisonbg and I talked at length today, and were thinking that such feature may end up not being necessary, because there are better ways to implement a similar experience. In that case, we can ditch the container object, and the `main` property value could be the value of interchange.

cc @ellisonbg @jasongrout @blink1073 @afshin 

![browser](https://cloud.githubusercontent.com/assets/137289/23584065/b86ce61c-011b-11e7-9728-13916ee8ac81.gif)
