### PR TITLE
Feature universal context menus

### DIFF
--- a/examples/example-dockpanel/src/index.ts
+++ b/examples/example-dockpanel/src/index.ts
@@ -16,7 +16,7 @@ import {
 } from '@phosphor/messaging';
 
 import {
-  BoxPanel, CommandPalette, DockPanel, Menu, MenuBar, Widget
+  BoxPanel, CommandPalette, ContextMenu, DockPanel, Menu, MenuBar, Widget
 } from '@phosphor/widgets';
 
 import '../style/index.css';
@@ -252,8 +252,6 @@ function main(): void {
   menu3.title.label = 'View';
   menu3.title.mnemonic = 0;
 
-  let ctxt = createMenu();
-
   let bar = new MenuBar();
   bar.addMenu(menu1);
   bar.addMenu(menu2);
@@ -277,21 +275,30 @@ function main(): void {
   palette.addItem({ command: 'notebook:new', category: 'Notebook' });
   palette.id = 'palette';
 
+  let contextMenu = new ContextMenu({ commands });
+
   document.addEventListener('contextmenu', (event: MouseEvent) => {
-    event.preventDefault();
-    ctxt.open(event.clientX, event.clientY);
-    console.log('ctxt menu');
+    if (contextMenu.open(event)) {
+      event.preventDefault();
+    }
   });
 
+  contextMenu.addItem({ command: 'example:cut', selector: '.content' });
+  contextMenu.addItem({ command: 'example:copy', selector: '.content' });
+  contextMenu.addItem({ command: 'example:paste', selector: '.content' });
+
+  contextMenu.addItem({ command: 'example:one', selector: '.p-CommandPalette' });
+  contextMenu.addItem({ command: 'example:two', selector: '.p-CommandPalette' });
+  contextMenu.addItem({ command: 'example:three', selector: '.p-CommandPalette' });
+  contextMenu.addItem({ command: 'example:four', selector: '.p-CommandPalette' });
+  contextMenu.addItem({ command: 'example:black', selector: '.p-CommandPalette' });
+
+  contextMenu.addItem({ command: 'notebook:new', selector: '.p-CommandPalette-input' });
+  contextMenu.addItem({ command: 'example:save-on-exit', selector: '.p-CommandPalette-input' });
+  contextMenu.addItem({ command: 'example:open-task-manager', selector: '.p-CommandPalette-input' });
+  contextMenu.addItem({ type: 'separator', selector: '.p-CommandPalette-input' });
+
   document.addEventListener('keydown', (event: KeyboardEvent) => {
-    // if (!event.ctrlKey && !event.shiftKey && !event.metaKey && event.keyCode === 18) {
-    //   event.preventDefault();
-    //   event.stopPropagation();
-    //   bar.activeIndex = 0;
-    //   bar.activate();
-    // } else {
-    //   keymap.processKeydownEvent(event);
-    // }
     commands.processKeydownEvent(event);
   });
 

--- a/packages/widgets/src/contextmenu.ts
+++ b/packages/widgets/src/contextmenu.ts
@@ -1,0 +1,297 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2017, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+import {
+  ArrayExt, each
+} from '@phosphor/algorithm';
+
+import {
+  CommandRegistry
+} from '@phosphor/commands';
+
+import {
+  DisposableDelegate, IDisposable
+} from '@phosphor/disposable';
+
+import {
+  Selector
+} from '@phosphor/domutils';
+
+import {
+  Menu
+} from './menu';
+
+
+/**
+ * An object which implements a universal context menu.
+ *
+ * #### Notes
+ * The items shown in the context menu are determined by CSS selector
+ * matching against the DOM hierarchy at the site of the mouse click.
+ * This is similar in concept to how keyboard shortcuts are matched
+ * in the command registry.
+ */
+export
+class ContextMenu {
+  /**
+   * Construct a new context menu.
+   *
+   * @param options - The options for initializing the menu.
+   */
+  constructor(options: ContextMenu.IOptions) {
+    this.menu = new Menu(options);
+  }
+
+  /**
+   * The menu widget which displays the matched context items.
+   */
+  readonly menu: Menu;
+
+  /**
+   * Add an item to the context menu.
+   *
+   * @param options - The options for creating the item.
+   *
+   * @returns A disposable which will remove the item from the menu.
+   */
+  addItem(options: ContextMenu.IItemOptions): IDisposable {
+    // Create an item from the given options.
+    let item = Private.createItem(options);
+
+    // Add the item to the internal array.
+    this._items.push(item);
+
+    // Return a disposable which will remove the item.
+    return new DisposableDelegate(() => {
+      ArrayExt.removeFirstOf(this._items, item);
+    });
+  }
+
+  /**
+   * Open the context menu in response to a `'contextmenu'` event.
+   *
+   * @param event - The `'contextmenu'` event of interest.
+   *
+   * @returns `true` if the menu was opened, or `false` if no items
+   *   matched the event and the menu was not opened.
+   *
+   * #### Notes
+   * This method will populate the context menu with items which match
+   * the propagation path of the event, then open the menu at the mouse
+   * position indicated by the event.
+   */
+  open(event: MouseEvent): boolean {
+    // Clear the current contents of the context menu.
+    this.menu.clearItems();
+
+    // Bail early if there are no items to match.
+    if (this._items.length === 0) {
+      return false;
+    }
+
+    // Find the matching items for the event.
+    let items = Private.matchItems(this._items, event);
+
+    // Bail if there are no matching items.
+    if (items.length === 0) {
+      return false;
+    }
+
+    // Add the filtered items to the menu.
+    each(items, item => { this.menu.addItem(item); });
+
+    // Open the context menu at the current mouse position.
+    this.menu.open(event.clientX, event.clientY);
+
+    // Indicate success.
+    return true;
+  }
+
+  private _items: Private.IItem[] = [];
+}
+
+
+/**
+ * The namespace for the `ContextMenu` class statics.
+ */
+export
+namespace ContextMenu {
+  /**
+   * An options object for initializing a context menu.
+   */
+  export
+  interface IOptions {
+    /**
+     * The command registry to use with the context menu.
+     */
+    commands: CommandRegistry;
+
+    /**
+     * A custom renderer for use with the context menu.
+     */
+    renderer?: Menu.IRenderer;
+  }
+
+  /**
+   * An options object for creating a context menu item.
+   */
+  export
+  interface IItemOptions extends Menu.IItemOptions {
+    /**
+     * The CSS selector for the context menu item.
+     *
+     * The context menu item will only be displayed in the context menu
+     * when the selector matches a node on the propagation path of the
+     * contextmenu event. This allows the menu item to be restricted to
+     * user-defined contexts.
+     *
+     * The selector must not contain commas.
+     */
+    selector: string;
+
+    /**
+     * The rank for the item.
+     *
+     * The rank is used as a tie-breaker when ordering context menu
+     * items for display. Items are sorted in the following order:
+     *   1. Depth in the DOM tree (deeper is better)
+     *   2. Selector specificity (higher is better)
+     *   3. Rank (lower is better)
+     *
+     * The default rank is `Infinity`.
+     */
+    rank?: number;
+  }
+}
+
+
+/**
+ * The namespace for the module implementation details.
+ */
+namespace Private {
+  /**
+   * A normalized item for a context menu.
+   */
+  export
+  interface IItem extends Menu.IItemOptions {
+    /**
+     * The selector for the item.
+     */
+    selector: string;
+
+    /**
+     * The rank for the item.
+     */
+    rank: number;
+  }
+
+  /**
+   * Create a normalized context menu item from an options object.
+   */
+  export
+  function createItem(options: ContextMenu.IItemOptions): IItem {
+    let selector = validateSelector(options.selector);
+    let rank = options.rank !== undefined ? options.rank : Infinity;
+    return { ...options, selector, rank };
+  }
+
+  /**
+   * Find the items which match a context menu event.
+   *
+   * The results are sorted by DOM level, specificity, and rank.
+   */
+  export
+  function matchItems(items: IItem[], event: MouseEvent): IItem[] {
+    // Set up the result array.
+    let result: IItem[] = [];
+
+    // Copy the items array to allow in-place modification.
+    let temp: Array<IItem | null> = items.slice();
+
+    // Set up the limits of the DOM search.
+    let target = event.target as (Element | null);
+    let current = event.currentTarget as (Element | null);
+
+    // Walk up the DOM hierarchy searching for matches.
+    while (target !== null) {
+      // Set up the match array for this DOM level.
+      let matches: IItem[] = [];
+
+      // Search the remaining items for matches.
+      for (let i = 0, n = temp.length; i < n; ++i) {
+        // Fetch the item.
+        let item = temp[i];
+
+        // Skip items which are already consumed.
+        if (!item) {
+          continue;
+        }
+
+        // Skip items which do not match the element.
+        if (!Selector.matches(target, item.selector)) {
+          continue;
+        }
+
+        // Add the matched item to the result for this DOM level.
+        matches.push(item);
+
+        // Mark the item as consumed.
+        temp[i] = null;
+      }
+
+      // Sort the matches for this level and add them to the results.
+      if (matches.length !== 0) {
+        matches.sort(itemCmp);
+        result.push(...matches);
+      }
+
+      // Stop searching at the limits of the DOM range.
+      if (target === current) {
+        break;
+      }
+
+      // Step to the parent DOM level.
+      target = target.parentElement;
+    }
+
+    // Return the matched and sorted results.
+    return result;
+  }
+
+  /**
+   * Validate the selector for a menu item.
+   *
+   * This returns the validated selector, or throws if the selector is
+   * invalid or contains commas.
+   */
+  function validateSelector(selector: string): string {
+    if (selector.indexOf(',') !== -1) {
+      throw new Error(`Selector cannot contain commas: ${selector}`);
+    }
+    if (!Selector.isValid(selector)) {
+      throw new Error(`Invalid selector: ${selector}`);
+    }
+    return selector;
+  }
+
+  /**
+   * A sort comparison function for a context menu item.
+   */
+  function itemCmp(a: IItem, b: IItem): number {
+    // Sort first based on selector specificity.
+    let s1 = Selector.calculateSpecificity(a.selector);
+    let s2 = Selector.calculateSpecificity(b.selector);
+    if (s1 !== s2) {
+      return s1 - s2;
+    }
+
+    // If specificities are equal, sort based on rank.
+    let r1 = a.rank;
+    let r2 = b.rank;
+    return r1 === r2 ? 0 : r1 < r2 ? -1 : 1;  // Infinity-safe
+  }
+}

--- a/packages/widgets/src/contextmenu.ts
+++ b/packages/widgets/src/contextmenu.ts
@@ -217,7 +217,7 @@ namespace Private {
     let result: IItem[] = [];
 
     // Copy the items array to allow in-place modification.
-    let temp: Array<IItem | null> = items.slice();
+    let availableItems: Array<IItem | null> = items.slice();
 
     // Set up the limits of the DOM search.
     let target = event.target as (Element | null);
@@ -229,9 +229,9 @@ namespace Private {
       let matches: IItem[] = [];
 
       // Search the remaining items for matches.
-      for (let i = 0, n = temp.length; i < n; ++i) {
+      for (let i = 0, n = availableItems.length; i < n; ++i) {
         // Fetch the item.
-        let item = temp[i];
+        let item = availableItems[i];
 
         // Skip items which are already consumed.
         if (!item) {
@@ -247,7 +247,7 @@ namespace Private {
         matches.push(item);
 
         // Mark the item as consumed.
-        temp[i] = null;
+        availableItems[i] = null;
       }
 
       // Sort the matches for this level and add them to the results.

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -9,6 +9,7 @@ export * from './boxengine';
 export * from './boxlayout';
 export * from './boxpanel';
 export * from './commandpalette';
+export * from './contextmenu';
 export * from './docklayout';
 export * from './dockpanel';
 export * from './focustracker';


### PR DESCRIPTION
This implements universal context menus. The gif below shows the context menu being launched from right-clicking on various widgets. The CSS selectors for the menu items control which items are shown the menu. When clicking near the tab bar, no menu items are matched, so the application instead shows the default browser context menu. *The ContextMenu object does not make this decision for you, it is up to the application to decide if/when to show the browser menu or custom context menu. The ContextMenu object returns `false` from its `open` method when there are no matching items. The example here uses that flag to decide whether to show the default browser menu.* 

cc @ellisonbg @jasongrout @blink1073 @afshin 

![browser](https://cloud.githubusercontent.com/assets/137289/24005275/9053f854-0a36-11e7-94d2-75a9b3d4dd65.gif)

