### PR TITLE
JSONObject index type should include undefined

### DIFF
--- a/packages/coreutils/src/json.ts
+++ b/packages/coreutils/src/json.ts
@@ -213,7 +213,7 @@ namespace JSONExt {
 
     // Compare the values for equality.
     for (let key in first) {
-      if (!deepEqual(first[key], second[key])) {
+      if (!deepEqual(first[key]!, second[key]!)) {
         return false;
       }
     }
@@ -239,7 +239,7 @@ namespace JSONExt {
   function deepObjectCopy(value: JSONObject): JSONObject {
     let result: JSONObject = {};
     for (let key in value) {
-      result[key] = deepCopy(value[key]);
+      result[key] = deepCopy(value[key]!);
     }
     return result;
   }

--- a/packages/coreutils/src/json.ts
+++ b/packages/coreutils/src/json.ts
@@ -25,7 +25,7 @@ type JSONValue = JSONPrimitive | JSONObject | JSONArray;
  * A type definition for a JSON object.
  */
 export
-interface JSONObject { [key: string]: JSONValue; }
+interface JSONObject { [key: string]: JSONValue | undefined; }
 
 
 /**


### PR DESCRIPTION
Missing keys will give `undefined` for a JSONObject, so include in typing.