### PR TITLE
Fix #317

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -452,7 +452,7 @@ class Application<T extends Widget> {
    * A subclass may reimplement this method as needed.
    */
   protected attachShell(id: string): void {
-    Widget.attach(this.shell, document.getElementById(id) || document.body);
+    Widget.attach(this.shell, (id && document.getElementById(id)) || document.body);
   }
 
   /**


### PR DESCRIPTION
This works around a console warning on FF when the given id is the empty string. Fixes #317.