### PR TITLE
Don't overflow item content

### DIFF
--- a/packages/widgets/style/commandpalette.css
+++ b/packages/widgets/style/commandpalette.css
@@ -52,6 +52,7 @@
 
 .p-CommandPalette-itemContent {
   flex: 1 1 auto;
+  overflow: hidden;
 }
 
 


### PR DESCRIPTION
This fixes overflow behavior for command palette items so that long labels are truncated with ellipses.