### PR TITLE
Provide an option to uniformly resize any sections

### DIFF
--- a/examples/example-datagrid/src/index.ts
+++ b/examples/example-datagrid/src/index.ts
@@ -235,14 +235,14 @@ function main(): void {
   let grid1 = new DataGrid({ style: blueStripeStyle });
   grid1.model = model1;
 
-  let grid2 = new DataGrid({ style: brownStripeStyle });
+  let grid2 = new DataGrid({ style: brownStripeStyle, uniformResizing: 'body-column' });
   grid2.model = model2;
 
   let grid3 = new DataGrid();
   grid3.cellRenderers.set('body', {}, fgColorFloatRenderer);
   grid3.model = model3;
 
-  let grid4 = new DataGrid();
+  let grid4 = new DataGrid({ uniformResizing: 'all' });
   grid4.cellRenderers.set('body', {}, bgColorFloatRenderer);
   grid4.model = model4;
 

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -365,9 +365,34 @@ class DataGrid extends Widget {
     this._uniformResizing = value;
 
     // Reset the baseSizes for the relevant sections.
-    // TODO
-
-    //this._syncViewport();
+    switch (value) {
+      case 'all':
+        this.resetSections('row');
+        this.resetSections('column');
+        this.resetSections('row-header');
+        this.resetSections('column-header');
+        break;
+      case 'body':
+        this.resetSections('row');
+        this.resetSections('column');
+        break;
+      case 'header':
+        this.resetSections('row-header');
+        this.resetSections('column-header');
+        break;
+      case 'body-row':
+        this.resetSections('row');
+        break;
+      case 'body-column':
+        this.resetSections('column');
+        break;
+      case 'header-row':
+        this.resetSections('row-header');
+        break;
+      case 'header-column':
+        this.resetSections('column-header');
+        break;
+    }
   }
 
   /**


### PR DESCRIPTION
This is useful in particular for renderers showing non-textual data (a heatmap, for ex - https://nmichaud.github.io/uniform-resize)

