### PR TITLE
work around for error `can't resolve crypto`

### DIFF
--- a/packages/coreutils/src/random.ts
+++ b/packages/coreutils/src/random.ts
@@ -39,7 +39,7 @@ namespace Random {
     // Look up the crypto module if available.
     const crypto: any = (
       (typeof window !== 'undefined' && (window.crypto || window.msCrypto)) ||
-      (typeof require !== 'undefined' && require('crypto')) || null
+      (typeof require !== 'undefined') || null
     );
 
     // Modern browsers and IE 11


### PR DESCRIPTION
I received the following error in my console when installing `"@phosphor/coreutils": "^1.3.0"`.

```bash
ERROR in ./node_modules/@phosphor/coreutils/lib/random.js
Module not found: Error: Can't resolve 'crypto' in 'C:\Users\sbiggs\github\monorepo\Applications\not-in-regular-use\cca-photo-drop\node_modules\@phosphor\coreutils\lib'
i ｢wdm｣: Failed to compile.
```

I worked around this error by applying this patch.
