### PR TITLE
Restore tab drop zone

### DIFF
--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -1026,6 +1026,7 @@ namespace DockPanel {
      * The size of the right edge drop zone.
      */
     right: number;
+
     /**
      * The size of the bottom edge drop zone.
      */

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -801,10 +801,11 @@ class DockPanel extends Widget {
       bottom = target!.bottom;
       break;
     case 'widget-tab':
+      const tabHeight = target!.tabBar.node.getBoundingClientRect().height;
       top = target!.top;
       left = target!.left;
       right = target!.right;
-      bottom = target!.bottom;
+      bottom = target!.bottom + target!.height - tabHeight;
       break;
     default:
       throw 'unreachable';


### PR DESCRIPTION
Fixes #360.

This restores the tab drop zone to the dock panel. The top root drop zone is also shrunk in order to conflict less with the top tab bar.

I've provided two options for the overlay: the first one adds the overlay of the same shape as the tab zone. The second one adds the overlay of the same shape as the center-drop-zone overlay. I'd appreciate thoughts about which one is better.

![tab-drop-zone1](https://user-images.githubusercontent.com/5728311/49250038-b62ec400-f3d2-11e8-8235-73f91230b791.gif)
![tab-drop-zone2](https://user-images.githubusercontent.com/5728311/49250041-b7f88780-f3d2-11e8-869b-e2b7657c9fd7.gif)

cc @jasongrout @blink1073 @tgeorgeux @ellisonbg 