### PR TITLE
Add observable disposable interface, delegate, and set. 

### DIFF
--- a/packages/disposable/package.json
+++ b/packages/disposable/package.json
@@ -40,7 +40,8 @@
     "watch": "tsc --build --watch"
   },
   "dependencies": {
-    "@phosphor/algorithm": "^1.1.3"
+    "@phosphor/algorithm": "^1.1.3",
+    "@phosphor/signaling": "^1.2.3"
   },
   "devDependencies": {
     "@types/chai": "^3.4.35",

--- a/packages/disposable/src/index.ts
+++ b/packages/disposable/src/index.ts
@@ -112,6 +112,7 @@ class ObservableDisposableDelegate extends DisposableDelegate implements IObserv
     }
     super.dispose();
     this._disposed.emit(undefined);
+    Signal.clearData(this);
   }
 
   private _disposed = new Signal<this, void>(this);
@@ -242,6 +243,7 @@ class ObservableDisposableSet extends DisposableSet implements IObservableDispos
     }
     super.dispose();
     this._disposed.emit(undefined);
+    Signal.clearData(this);
   }
 
   private _disposed = new Signal<this, void>(this);

--- a/packages/disposable/src/index.ts
+++ b/packages/disposable/src/index.ts
@@ -107,6 +107,9 @@ class ObservableDisposableDelegate extends DisposableDelegate implements IObserv
    * Dispose of the delegate and invoke the callback function.
    */
   dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
     super.dispose();
     this._disposed.emit(undefined);
   }
@@ -234,6 +237,9 @@ class ObservableDisposableSet extends DisposableSet implements IObservableDispos
    * Items are disposed in the order they are added to the set.
    */
   dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
     super.dispose();
     this._disposed.emit(undefined);
   }

--- a/packages/disposable/src/index.ts
+++ b/packages/disposable/src/index.ts
@@ -222,7 +222,7 @@ namespace DisposableSet {
  * An observable object which manages a collection of disposable items.
  */
 export
-class ObservableDisposableSet extends DisposableSet implements IObservableDisposable{
+class ObservableDisposableSet extends DisposableSet implements IObservableDisposable {
   /**
    * A signal emitted when the set is disposed.
    */

--- a/packages/disposable/src/index.ts
+++ b/packages/disposable/src/index.ts
@@ -9,6 +9,10 @@ import {
   IterableOrArrayLike, each
 } from '@phosphor/algorithm';
 
+import {
+  ISignal, Signal
+} from '@phosphor/signaling';
+
 
 /**
  * An object which implements the disposable pattern.
@@ -35,6 +39,18 @@ interface IDisposable {
    * after it has been disposed unless otherwise explicitly noted.
    */
   dispose(): void;
+}
+
+
+/**
+ * A disposable object with an observable `disposed` signal.
+ */
+export
+interface IObservableDisposable extends IDisposable {
+  /**
+   * A signal emitted when the object is disposed.
+   */
+  readonly disposed: ISignal<this, void>;
 }
 
 
@@ -76,6 +92,30 @@ class DisposableDelegate implements IDisposable {
 
 
 /**
+ * An observable disposable object which delegates to a callback function.
+ */
+export
+class ObservableDisposableDelegate extends DisposableDelegate implements IObservableDisposable {
+  /**
+   * A signal emitted when the delegate is disposed.
+   */
+  get disposed(): ISignal<this, void> {
+    return this._disposed;
+  }
+
+  /**
+   * Dispose of the delegate and invoke the callback function.
+   */
+  dispose(): void {
+    super.dispose();
+    this._disposed.emit(undefined);
+  }
+
+  private _disposed = new Signal<this, void>(this);
+}
+
+
+/**
  * An object which manages a collection of disposable items.
  */
 export
@@ -89,7 +129,7 @@ class DisposableSet implements IDisposable {
    * Test whether the set has been disposed.
    */
   get isDisposed(): boolean {
-    return this._disposed;
+    return this._isDisposed;
   }
 
   /**
@@ -99,10 +139,10 @@ class DisposableSet implements IDisposable {
    * Items are disposed in the order they are added to the set.
    */
   dispose(): void {
-    if (this._disposed) {
+    if (this._isDisposed) {
       return;
     }
-    this._disposed = true;
+    this._isDisposed = true;
     this._items.forEach(item => { item.dispose(); });
     this._items.clear();
   }
@@ -149,7 +189,7 @@ class DisposableSet implements IDisposable {
     this._items.clear();
   }
 
-  private _disposed = false;
+  private _isDisposed = false;
   private _items = new Set<IDisposable>();
 }
 
@@ -169,6 +209,54 @@ namespace DisposableSet {
   export
   function from(items: IterableOrArrayLike<IDisposable>): DisposableSet {
     let set = new DisposableSet();
+    each(items, item => { set.add(item) });
+    return set;
+  }
+}
+
+
+/**
+ * An observable object which manages a collection of disposable items.
+ */
+export
+class ObservableDisposableSet extends DisposableSet implements IObservableDisposable{
+  /**
+   * A signal emitted when the set is disposed.
+   */
+  get disposed(): ISignal<this, void> {
+    return this._disposed;
+  }
+
+  /**
+   * Dispose of the set and the items it contains.
+   *
+   * #### Notes
+   * Items are disposed in the order they are added to the set.
+   */
+  dispose(): void {
+    super.dispose();
+    this._disposed.emit(undefined);
+  }
+
+  private _disposed = new Signal<this, void>(this);
+}
+
+
+/**
+ * The namespace for the `ObservableDisposableSet` class statics.
+ */
+export
+namespace ObservableDisposableSet {
+  /**
+   * Create an observable disposable set from an iterable of items.
+   *
+   * @param items - The iterable or array-like object of interest.
+   *
+   * @returns A new disposable initialized with the given items.
+   */
+  export
+  function from(items: IterableOrArrayLike<IDisposable>): ObservableDisposableSet {
+    let set = new ObservableDisposableSet();
     each(items, item => { set.add(item) });
     return set;
   }

--- a/packages/disposable/tests/src/index.spec.ts
+++ b/packages/disposable/tests/src/index.spec.ts
@@ -10,7 +10,8 @@ import {
 } from 'chai';
 
 import {
-  DisposableDelegate, DisposableSet, IDisposable
+  DisposableDelegate, DisposableSet, IDisposable,
+  ObservableDisposableDelegate, ObservableDisposableSet
 } from '@phosphor/disposable';
 
 
@@ -74,6 +75,22 @@ describe('@phosphor/disposable', () => {
         delegate.dispose();
         delegate.dispose();
         expect(count).to.equal(1);
+      });
+
+    });
+
+  });
+
+  describe('ObservableDisposableDelegate', () => {
+
+    describe('#disposed', () => {
+
+      it('should be emitted when the delegate is disposed', () => {
+        let called = false;
+        let delegate = new ObservableDisposableDelegate(() => { });
+        delegate.disposed.connect(() => { called = true; });
+        delegate.dispose();
+        expect(called).to.equal(true);
       });
 
     });
@@ -277,4 +294,44 @@ describe('@phosphor/disposable', () => {
 
   });
 
+  describe('ObservableDisposableSet', () => {
+
+    describe('#disposed', () => {
+
+      it('should be emitted when the set is disposed', () => {
+        let called = false;
+        let set = new ObservableDisposableSet();
+        let item1 = new TestDisposable();
+        let item2 = new TestDisposable();
+        let item3 = new TestDisposable();
+        set.add(item1);
+        set.add(item2);
+        set.add(item3);
+        set.disposed.connect(() => {
+          expect(set.contains(item1)).to.equal(false);
+          expect(set.contains(item2)).to.equal(false);
+          expect(set.contains(item3)).to.equal(false);
+          expect(item1.isDisposed).to.equal(true);
+          expect(item2.isDisposed).to.equal(true);
+          expect(item3.isDisposed).to.equal(true);
+          called = true;
+        });
+        set.dispose();
+        expect(called).to.equal(true);
+      });
+
+    });
+
+    describe('.from()', () => {
+
+      it('should accept an iterable of disposable items', () => {
+        let item1 = new TestDisposable();
+        let item2 = new TestDisposable();
+        let item3 = new TestDisposable();
+        let set = ObservableDisposableSet.from([item1, item2, item3]);
+        expect(set).to.be.an.instanceof(ObservableDisposableSet);
+      });
+
+    });
+  });
 });

--- a/packages/disposable/tests/tsconfig.json
+++ b/packages/disposable/tests/tsconfig.json
@@ -24,7 +24,7 @@
   ],
   "references": [
     {
-      "path": "../../algorithm"
+      "path": ["../../algorithm", "../../signaling"]
     }
   ]
 }

--- a/packages/disposable/tests/tsconfig.json
+++ b/packages/disposable/tests/tsconfig.json
@@ -24,7 +24,10 @@
   ],
   "references": [
     {
-      "path": ["../../algorithm", "../../signaling"]
+      "path": "../../algorithm"
+    },
+    {
+      "path": "../../signaling"
     }
   ]
 }

--- a/packages/disposable/tsconfig.json
+++ b/packages/disposable/tsconfig.json
@@ -23,6 +23,9 @@
   "references": [
     {
       "path": "../algorithm"
-    }
+    },
+    {
+      "path": "../signaling"
+    },
   ]
 }

--- a/packages/widgets/src/widget.ts
+++ b/packages/widgets/src/widget.ts
@@ -10,7 +10,7 @@ import {
 } from '@phosphor/algorithm';
 
 import {
-  IDisposable
+  IObservableDisposable
 } from '@phosphor/disposable';
 
 import {
@@ -43,7 +43,7 @@ import {
  * content.
  */
 export
-class Widget implements IDisposable, IMessageHandler {
+class Widget implements IMessageHandler, IObservableDisposable {
   /**
    * Construct a new widget.
    *


### PR DESCRIPTION
This PR adds:
* An `IObservableDisposable` interface that extends the `IDisposable` by adding a `disposed` signal that emits when the object is disposed.
* An `ObservableDisposableDelegate` that extends the `DisposableDelegate` with a `disposed` signal.
* An `ObservableDisposableSet` that extends the `DisposableSet` with a `disposed` signal.
* Tests for the two new classes.

The name "observable delegate" is quite long. If you can think of a shorter name, please do.