### PR TITLE
Initial governance model and principles for phosphor

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,58 @@
+# Governance of PhosphorJS
+
+## Principles of PhosphorJS
+
+* Take time to design and implement APIs that will stand the test of time.
+* Adopt minimal external dependencies.
+* Packages should have as narrow a scope as possible and solve one problem.
+* Performance matters. Always sweat the details.
+* Keep public APIs as minimal as possible.
+* Packages should be loosely coupled and useful on their own.
+* Offer exceptionally clean implementation.
+* Build escape hatches into the APIs for extensibility.
+* PhosphorJS is about code, documentation, and technical excellence. Leave
+  non-technical discussions and opinions at the door.
+* Code of Conduct: Be nice.
+
+## Governance Model
+
+* PhosphorJS is governed by a group of Package Maintainers and a Chief Executive,
+  that lead the project.
+* Package Maintainers are responsible for one or more PhosphorJS packages. Each
+  package shall have a one or more maintainers.
+* A broader group of Contributors works with the Package Maintainers and Chief
+  Executive on the code base and documentation of the Project.
+* Package Maintainers shall individually be responsible:
+  - To make technical, API, and design decisions related to their Package;
+  - To consult with and build consensus among other Package Maintainers and
+    contributors;
+  - To work with other contributors to develop and maintain the source code and
+    documentation of their Package;
+  - To maintain a roadmap for the Package, updated on a quarterly basis;
+  - To maintain the API and narrative documentation of their Package;
+  - To ensure the software in their Package follows the principles of PhosphorJS;
+  - To maintain GitHub issues that track work related to the Package.
+* The Chief Executive shall be responsible:
+  - To maintain the principles of PhosphorJS to guide the work of the project;
+  - To veto the approval of any Package Pull Requests;
+  - To veto any votes taken by the Package Maintainers;
+  - To provide senior technical and strategic input for the Packages and their
+    roadmaps;
+  - To act as a "super maintainer" of all packages;
+  - To cast a deciding vote in case of a tie in a vote of the Package
+    Maintainers.
+* Technical decisions that span multiple Packages shall be made by a majority
+  vote of the package maintainers.
+* Organizational and governance decisions shall be made by a 2/3 vote of the
+  Package Maintainers and explicit approval of the Chief Executive.
+* New package maintainers can be nominated by any Package Maintainer, and
+  approved by a majority vote of the current Package Maintainers.
+* Releases shall be approved by majority vote of the package maintainers.
+  Package maintainers can be removed by a 2/3 vote of no confidence of the other
+  Package Maintainers, or by the Chief Executive for flagrant violation of one
+  or more project principles.
+* New Packages can be proposed by any Package Maintainer. Such proposals must
+  identify a Package Maintainer for the new Package, and be approved by majority
+  vote of the Package Maintainers. If the Package Maintainer of the new Package
+  is not already a current Package Maintainer, the proposing Package Maintainer
+  shall mentor the new Package Maintainer for a 6 month period.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -41,7 +41,7 @@ Package Maintainers:
 * PhosphorJS is governed by a group of Package Maintainers and a Chief Executive,
   that lead the project.
 * Package Maintainers are responsible for one or more PhosphorJS packages. Each
-  package shall have a one or more maintainers.
+  package shall have one or more maintainers.
 * A broader group of Contributors works with the Package Maintainers and Chief
   Executive on the code base and documentation of the Project.
 * Package Maintainers shall individually be responsible:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,5 +1,27 @@
 # Governance of PhosphorJS
 
+Chief Executive: Chris Colbert
+
+Package Maintainers:
+
+* `algorithm`:
+* `application`:
+* `collections`:
+* `commands`:
+* `coreutils`:
+* `datagrid`:
+* `datastore`:
+* `default-theme`:
+* `disposable`:
+* `domutils`:
+* `dragdrop`:
+* `keyboard`:
+* `messaging`:
+* `properties`:
+* `signaling`:
+* `virtualdom`:
+* `widgets`:
+
 ## Principles of PhosphorJS
 
 * Take time to design and implement APIs that will stand the test of time.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,39 @@
-Phosphor
-========
+# PhosphorJS
 
 [![Build Status](https://travis-ci.org/phosphorjs/phosphor.svg?branch=master)](https://travis-ci.org/phosphorjs/phosphor)
 
-The [PhosphorJS](http://phosphorjs.github.io/) library.
+PhosphorJS is a set of JavaScript packages, written in TypeScript, that provide
+a rich set of widgets, layouts, events, and data structures. These enable
+developers to construct advanced, production-quality, desktop-like web
+applications that would be otherwise impossible using CSS alone.
+
+See the [PhosphorJS website](http://phosphorjs.github.io/) for more information.
+
+## Documentation
+
+The API documentation for the phosphor packages can be found in the links below:
+
+* [algorithm](http://phosphorjs.github.io/phosphor/api/algorithm/globals.html)
+* [application](http://phosphorjs.github.io/phosphor/api/application/globals.html)
+* [commands](http://phosphorjs.github.io/phosphor/api/commands/globals.html)
+* [coreutils](http://phosphorjs.github.io/phosphor/api/coreutils/globals.html)
+* [disposable](http://phosphorjs.github.io/phosphor/api/disposable/globals.html)
+* [domutils](http://phosphorjs.github.io/phosphor/api/domutils/globals.html)
+* [dragdrop](http://phosphorjs.github.io/phosphor/api/dragdrop/globals.html)
+* [keyboard](http://phosphorjs.github.io/phosphor/api/keyboard/globals.html)
+* [messaging](http://phosphorjs.github.io/phosphor/api/messaging/globals.html)
+* [properties](http://phosphorjs.github.io/phosphor/api/properties/globals.html)
+* [signaling](http://phosphorjs.github.io/phosphor/api/signaling/globals.html)
+* [virtualdom](http://phosphorjs.github.io/phosphor/api/virtualdom/globals.html)
+* [widgets](http://phosphorjs.github.io/phosphor/api/widgets/globals.html)
+
+
+## Governance
+
+PhosphorJS is led by a Chief Executive, Chris Colbert, and team of Package
+Maintainers according to the Principles of Phosphor. See our [Governance
+Document](https://github.com/phosphorjs/phosphor/blob/master/GOVERNANCE.md) for
+details.
+
+
+


### PR DESCRIPTION
@sccolbert @jasongrout @blink1073 @afshin @ian-r-rose @vidartf @saulshanabrook

This is an initial governance model for phosphor. @sccolbert and I have gone over this in a call.

Once this has been reviewed and merged, and an initial group of Package Maintainers are appointed, there are a number of outstanding questions to tackle, that we wanted to get the PM's input on:

- Determine response times for PRs and issues.
- How long to wait for CE vetos?
- Process around CE stepping down, electing a new one?
- How long do we give package maintainers to create initial tutorial documentation?
- How to manage GitHub milestones?
- How many votes are needed for a quorum?
  * Suggestion: 100% expected unless unable due to emergency. Votes are subject to a time limit (tbd). Maintainers missing a vote due to a non-emergency take a demerit.
  * Old language: “All votes described herein shall take place on GitHub (using thumbs up/down) and require all Package Maintainers to vote within X hours. “

