### PR TITLE
Add (de-)serialization to datastore

### DIFF
--- a/packages/datastore/src/datastore.ts
+++ b/packages/datastore/src/datastore.ts
@@ -6,7 +6,7 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 import {
-  each, IIterable, IIterator, iterItems, map, StringExt
+  each, IIterable, IIterator, iterItems, map, StringExt, toArray, toObject
 } from '@phosphor/algorithm';
 
 import {
@@ -24,6 +24,10 @@ import {
 import {
   ISignal, Signal
 } from '@phosphor/signaling';
+
+import {
+  Record
+} from './record';
 
 import {
   Schema, validateSchema
@@ -82,9 +86,19 @@ class Datastore implements IIterable<Table<Schema>>, IMessageHandler, IDisposabl
     };
 
     const tables = new BPlusTree<Table<Schema>>(Private.recordCmp);
-    tables.assign(map(schemas, s => {
-      return Table.create(s, context);
-    }));
+    if (options.restoreState) {
+      // If passed state to restore, pass the intital state to recreate each
+      // table
+      const state = JSON.parse(options.restoreState);
+      tables.assign(map(schemas, s => {
+        return Table.recreate(s, context, state[s.id] || []);
+      }));
+    } else {
+      // Otherwise, simply create a new, empty table
+      tables.assign(map(schemas, s => {
+        return Table.create(s, context);
+      }));
+    }
 
     return new Datastore(context, tables, options.broadcastHandler);
   }
@@ -308,6 +322,19 @@ class Datastore implements IIterable<Table<Schema>>, IMessageHandler, IDisposabl
   }
 
   /**
+   * Serialize the state of the datastore to a string.
+   *
+   * @returns The serialized state.
+   */
+  toString(): string {
+    return JSON.stringify(toObject(
+      map(this, (table): [string, Record<Schema>[]] => {
+        return [table.schema.id, toArray(table)];
+      })
+    ));
+  }
+
+  /**
    * Create a new datastore.
    *
    * @param id - The unique id of the datastore.
@@ -492,6 +519,11 @@ namespace Datastore {
      * An optional transaction id factory to override the default.
      */
     transactionIdFactory?: TransactionIdFactory;
+
+    /**
+     * Initialize the state to a previously serialized one.
+     */
+    restoreState?: string;
   }
 
   /**

--- a/packages/datastore/src/table.ts
+++ b/packages/datastore/src/table.ts
@@ -6,7 +6,7 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 import {
-  IIterable, IIterator, StringExt
+  IIterable, IIterator, StringExt, IterableOrArrayLike
 } from '@phosphor/algorithm';
 
 import {
@@ -44,6 +44,21 @@ class Table<S extends Schema> implements IIterable<Record<S>> {
    */
   static create<U extends Schema>(schema: U, context: Datastore.Context): Table<U> {
     return new Table<U>(schema, context);
+  }
+
+  /**
+   * @internal
+   *
+   * Create a new datastore table with a previously exported state.
+   *
+   * @param schema - The schema for the table.
+   *
+   * @param context - The datastore context.
+   *
+   * @returns A new datastore table.
+   */
+  static recreate<U extends Schema>(schema: U, context: Datastore.Context, records: IterableOrArrayLike<Record<U>>): Table<U> {
+    return new Table<U>(schema, context, records);
   }
 
   /**
@@ -198,9 +213,12 @@ class Table<S extends Schema> implements IIterable<Record<S>> {
    *
    * @param context - The datastore context.
    */
-  private constructor(schema: S, context: Datastore.Context) {
+  private constructor(schema: S, context: Datastore.Context, records?: IterableOrArrayLike<Record<S>>) {
     this.schema = schema;
     this._context = context;
+    if (records) {
+      this._records.assign(records);
+    }
   }
 
   private _context: Datastore.Context;

--- a/packages/datastore/tests/src/datastore.spec.ts
+++ b/packages/datastore/tests/src/datastore.spec.ts
@@ -53,6 +53,27 @@ let schema2: TestSchema = {
   }
 };
 
+let state = {
+  [schema1.id]: [
+    {
+      content: 'Lorem Ipsum',
+      count: 42,
+      enabled: true,
+      links: ['www.example.com'],
+      metadata: { id: 'myidentifier' }
+    }
+  ],
+  [schema2.id]: [
+    {
+      content: 'Ipsum Lorem',
+      count: 33,
+      enabled: false,
+      links: ['www.example.com', 'https://github.com/phosphor/phosphorjs'],
+      metadata: null
+    }
+  ]
+};
+
 class LoggingMessageHandler implements IMessageHandler {
   processMessage(msg: Message): void {
     switch(msg.type) {
@@ -109,6 +130,17 @@ describe('@phosphor/datastore', () => {
         expect(() => {
           Datastore.create({ id: 1, schemas: [invalid2] });
         }).to.throw(/validation failed/);
+      });
+
+      it('should restore valid state', () => {
+        let datastore = Datastore.create({
+          id: 1,
+          schemas: [schema1, schema2],
+          restoreState: JSON.stringify(state)
+        });
+
+        let reexport = datastore.toString();
+        expect(JSON.parse(reexport)).to.eql(state);
       });
 
     });

--- a/packages/datastore/tests/src/datastore.spec.ts
+++ b/packages/datastore/tests/src/datastore.spec.ts
@@ -143,6 +143,22 @@ describe('@phosphor/datastore', () => {
         expect(JSON.parse(reexport)).to.eql(state);
       });
 
+      it('should restore partial state', () => {
+        let partialState = {[schema1.id]: state[schema1.id] };
+        let datastore = Datastore.create({
+          id: 1,
+          schemas: [schema1, schema2],
+          restoreState: JSON.stringify(partialState)
+        });
+
+        let reexport = datastore.toString();
+        expect(JSON.parse(reexport)).to.eql(
+          {
+            ...partialState,
+            [schema2.id]: []
+          });
+      });
+
     });
 
     describe('dispose()', () => {


### PR DESCRIPTION
Allows the state of a datastore to be serialized and restored. Note: The state can only be restored on initialization. Mainly meant to enable checkpoints.

Also includes a simple round-trip test