### PR TITLE
Fix a discriminant type attribute to be readonly

### DIFF
--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -1006,7 +1006,7 @@ namespace Private {
     /**
      * The discriminated type of the object.
      */
-    type: 'item';
+    readonly type: 'item';
 
     /**
      * The command item which was matched.


### PR DESCRIPTION
@sccolbert mentioned this attribute should be readonly in a walkthrough of Phosphor code.