### PR TITLE
Add datastore helper functions.

### DIFF
--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typedoc": "~0.12.0",
+    "typedoc": "~0.15.0",
     "typescript": "~3.5.1"
   }
 }

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -50,6 +50,6 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typedoc": "~0.12.0",
-    "typescript": "~3.0.3"
+    "typescript": "~3.5.1"
   }
 }

--- a/packages/datastore/src/datastore.ts
+++ b/packages/datastore/src/datastore.ts
@@ -14,7 +14,7 @@ import {
 } from '@phosphor/collections';
 
 import {
-  IDisposable
+  DisposableDelegate, IDisposable
 } from '@phosphor/disposable';
 
 import {
@@ -24,6 +24,10 @@ import {
 import {
   ISignal, Signal
 } from '@phosphor/signaling';
+
+import {
+  Record
+} from './record';
 
 import {
   Schema, validateSchema
@@ -607,6 +611,290 @@ namespace Datastore {
    */
   export
   type TransactionIdFactory = (version: number, storeId: number) => string;
+
+  /**
+   * A helper function to wrap an update to the datastore in calls to
+   * `beginTransaction` and `endTransaction`.
+   *
+   * @param datastore: the datastore to which to apply the update.
+   *
+   * @param update: A function that performs the update on the datastore.
+   *   The function is called with a transaction id string, in case the
+   *   user wishes to store the transaction ID for later use.
+   *
+   * @returns the transaction ID.
+   *
+   * #### Notes
+   * If the datastore is already in a transaction, this does not attempt
+   * to start a new one, and returns an empty string for the transaction
+   * id. This allows for transactions to be composed a bit more easily.
+   */
+  export function withTransaction(
+    datastore: Datastore,
+    update: (id: string) => void
+  ): string {
+    let id = '';
+    if (!datastore.inTransaction) {
+      id = datastore.beginTransaction();
+    }
+    try {
+      update(id);
+    } finally {
+      if (id) {
+        datastore.endTransaction();
+      }
+    }
+    return id;
+  }
+
+  /**
+   * An interface for referring to a specific table in a datastore.
+   */
+  export type TableLocation<S extends Schema> = {
+    /**
+     * The datastore in question.
+     */
+    datastore: Datastore;
+
+    /**
+     * The schema in question. This schema must exist in the datastore,
+     * or an error may result in its usage.
+     */
+    schema: S;
+  };
+
+  /**
+   * An interface for referring to a specific record in a datastore.
+   */
+  export type RecordLocation<S extends Schema> = TableLocation<S> & {
+    /**
+     * The record in question.
+     */
+    record: string;
+  };
+
+  /**
+   * An interface for referring to a specific field in a datastore.
+   *
+   * #### Notes
+   * The field must exist in the schema.
+   */
+  export type FieldLocation<
+    S extends Schema,
+    F extends keyof S['fields']
+  > = RecordLocation<S> & {
+    /**
+     * The field in question.
+     */
+    field: F;
+  };
+
+  /**
+   * Get a given table by its location.
+   *
+   * @param loc: The table location.
+   *
+   * @returns the table.
+   */
+  export function getTable<S extends Schema>(loc: TableLocation<S>): Table<S> {
+    return loc.datastore.get(loc.schema);
+  }
+
+  /**
+   * Get a given record by its location.
+   *
+   * @param loc: The record location.
+   *
+   * @returns the record, or undefined if it does not exist.
+   */
+  export function getRecord<S extends Schema>(
+    loc: RecordLocation<S>
+  ): Record.Value<S> | undefined {
+    return loc.datastore.get(loc.schema).get(loc.record);
+  }
+
+  /**
+   * Get a given field by its location.
+   *
+   * @param loc: the field location.
+   *
+   * @returns the field in question.
+   *
+   * #### Notes
+   * This will throw an error if the record does not exist in the given table.
+   */
+  export function getField<S extends Schema, F extends keyof S['fields']>(
+    loc: FieldLocation<S, F>
+  ): S['fields'][F]['ValueType'] {
+    const record = loc.datastore.get(loc.schema).get(loc.record);
+    if (!record) {
+      throw Error(`The record ${loc.record} could not be found`);
+    }
+    return record[loc.field];
+  }
+
+  /**
+   * Update a table.
+   *
+   * @param loc: the table location.
+   *
+   * @param update: the update to the table.
+   *
+   * #### Notes
+   * This does not begin a transaction, so usage of this function should be
+   * combined with `beginTransaction`/`endTransaction`, or `withTransaction`.
+   */
+  export function updateTable<S extends Schema>(
+    loc: TableLocation<S>,
+    update: Table.Update<S>
+  ): void {
+    let table = loc.datastore.get(loc.schema);
+    table.update(update);
+  }
+
+  /**
+   * Update a record in a table.
+   *
+   * @param loc: the record location.
+   *
+   * @param update: the update to the record.
+   *
+   * #### Notes
+   * This does not begin a transaction, so usage of this function should be
+   * combined with `beginTransaction`/`endTransaction`, or `withTransaction`.
+   */
+  export function updateRecord<S extends Schema>(
+    loc: RecordLocation<S>,
+    update: Record.Update<S>
+  ): void {
+    let table = loc.datastore.get(loc.schema);
+    table.update({
+      [loc.record]: update
+    });
+  }
+
+  /**
+   * Update a field in a table.
+   *
+   * @param loc: the field location.
+   *
+   * @param update: the update to the field.
+   *
+   * #### Notes
+   * This does not begin a transaction, so usage of this function should be
+   * combined with `beginTransaction`/`endTransaction`, or `withTransaction`.
+   */
+  export function updateField<S extends Schema, F extends keyof S['fields']>(
+    loc: FieldLocation<S, F>,
+    update: S['fields'][F]['UpdateType']
+  ): void {
+    let table = loc.datastore.get(loc.schema);
+    // TODO: this cast may be made unnecessary once microsoft/TypeScript#13573
+    // is fixed, possibly by microsoft/TypeScript#26797 lands.
+    table.update({
+      [loc.record]: {
+        [loc.field]: update
+      } as Record.Update<S>
+    });
+  }
+
+  /**
+   * Listen to changes in a table. Changes to other tables are ignored.
+   *
+   * @param loc: the table location.
+   *
+   * @param slot: a callback function to invoke when the table changes.
+   *
+   * @returns an `IDisposable` that can be disposed to remove the listener.
+   */
+  export function listenTable<S extends Schema>(
+    loc: TableLocation<S>,
+    slot: (source: Datastore, args: Table.Change<S>) => void,
+    thisArg?: any
+  ): IDisposable {
+    // A wrapper change signal connection function.
+    const wrapper = (source: Datastore, args: Datastore.IChangedArgs) => {
+      // Ignore changes that don't match the requested record.
+      if (!args.change[loc.schema.id]) {
+        return;
+      }
+      // Otherwise, call the slot.
+      const tc = args.change[loc.schema.id]! as Table.Change<S>;
+      slot.call(thisArg, source, tc);
+    };
+    loc.datastore.changed.connect(wrapper);
+    return new DisposableDelegate(() => {
+      loc.datastore.changed.disconnect(wrapper);
+    });
+  }
+
+  /**
+   * Listen to changes in a record in a table. Changes to other tables and
+   * other records in the same table are ignored.
+   *
+   * @param loc: the record location.
+   *
+   * @param slot: a callback function to invoke when the record changes.
+   *
+   * @returns an `IDisposable` that can be disposed to remove the listener.
+   */
+  export function listenRecord<S extends Schema>(
+    loc: RecordLocation<S>,
+    slot: (source: Datastore, args: Record.Change<S>) => void,
+    thisArg?: any
+  ): IDisposable {
+    // A wrapper change signal connection function.
+    const wrapper = (source: Datastore, args: Datastore.IChangedArgs) => {
+      // Ignore changes that don't match the requested record.
+      if (
+        !args.change[loc.schema.id] ||
+        !args.change[loc.schema.id][loc.record]
+      ) {
+        return;
+      }
+      // Otherwise, call the slot.
+      const tc = args.change[loc.schema.id]! as Table.Change<S>;
+      slot.call(thisArg, source, tc[loc.record]);
+    };
+    loc.datastore.changed.connect(wrapper);
+    return new DisposableDelegate(() => {
+      loc.datastore.changed.disconnect(wrapper);
+    });
+  }
+
+  /**
+   * Listen to changes in a fields in a table. Changes to other tables, other
+   * records in the same table, and other fields in the same record are ignored.
+   *
+   * @param loc: the field location.
+   *
+   * @param slot: a callback function to invoke when the field changes.
+   *
+   * @returns an `IDisposable` that can be disposed to remove the listener.
+   */
+  export function listenField<S extends Schema, F extends keyof S['fields']>(
+    loc: FieldLocation<S, F>,
+    slot: (source: Datastore, args: S['fields'][F]['ChangeType']) => void,
+    thisArg?: any
+  ): IDisposable {
+    const wrapper = (source: Datastore, args: Datastore.IChangedArgs) => {
+      // Ignore changes that don't match the requested field.
+      if (
+        !args.change[loc.schema.id] ||
+        !args.change[loc.schema.id][loc.record] ||
+        !args.change[loc.schema.id][loc.record][loc.field as string]
+      ) {
+        return;
+      }
+      // Otherwise, call the slot.
+      const tc = args.change[loc.schema.id]! as Table.Change<S>;
+      slot.call(thisArg, source, tc[loc.record][loc.field]);
+    };
+    loc.datastore.changed.connect(wrapper);
+    return new DisposableDelegate(() => {
+      loc.datastore.changed.disconnect(wrapper);
+    });
+  }
 }
 
 

--- a/packages/datastore/tsconfig.json
+++ b/packages/datastore/tsconfig.json
@@ -11,7 +11,7 @@
     "target": "ES5",
     "outDir": "lib",
     "rootDir": "src",
-    "lib": ["dom", "es5", "es2015.collection", "es2015.promise"],
+    "lib": ["dom", "es6"],
     "types": []
   },
   "include": [

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from '@phosphor/algorithm';
 
 
+
 /**
  * A type alias for a slot function.
  *
@@ -606,6 +607,7 @@ namespace Private {
    */
   const schedule = (() => {
     let ok = typeof requestAnimationFrame === 'function';
+    // @ts-ignore
     return ok ? requestAnimationFrame : setImmediate;
   })();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,6 +1111,13 @@ babel-code-frame@^6.11.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
+backbone@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.4.0.tgz#54db4de9df7c3811c3f032f34749a4cd27f3bd12"
+  integrity sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==
+  dependencies:
+    underscore ">=1.8.3"
+
 backo2@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
@@ -2814,6 +2821,15 @@ fs-extra@^7.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@~4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
@@ -3061,6 +3077,11 @@ graceful-fs@^4.1.15:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
+graceful-fs@^4.2.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
+  integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
+
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
@@ -3083,6 +3104,17 @@ handlebars@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
   integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+  dependencies:
+    neo-async "^2.6.0"
+    optimist "^0.6.1"
+    source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
+handlebars@^4.1.2:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.4.3.tgz#180bae52c1d0e9ec0c15d7e82a4362d662762f6e"
+  integrity sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -3193,6 +3225,11 @@ he@1.1.1:
 highlight.js@^9.0.0:
   version "9.12.0"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
+
+highlight.js@^9.15.8:
+  version "9.15.10"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.10.tgz#7b18ed75c90348c045eef9ed08ca1319a2219ad2"
+  integrity sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -3700,6 +3737,11 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
+jquery@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
+
 js-base64@^2.1.9:
   version "2.4.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.9.tgz#748911fb04f48a60c4771b375cac45a80df11c03"
@@ -4110,6 +4152,11 @@ lodash@^4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 log-symbols@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
@@ -4155,6 +4202,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lunr@^2.3.6:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.7.tgz#05ccf3af9d0e169b8f432c97e02fc1bdf3f36343"
+  integrity sha512-HjFSiy0Y0qZoW5OA1I6qBi7OnsDdqQnaUr03jhorh30maQoaP+4lQCKklYE3Nq3WJMSUfuBl6N+bKY5wxCb9hw==
 
 macos-release@^2.2.0:
   version "2.2.0"
@@ -4204,6 +4256,11 @@ map-visit@^1.0.0:
 marked@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
+
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
@@ -5442,6 +5499,11 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
+progress@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -6057,6 +6119,15 @@ shelljs@^0.8.2:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
+shelljs@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
+  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -6648,6 +6719,33 @@ typedoc-default-themes@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
 
+typedoc-default-themes@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.6.0.tgz#7e73bf54dd9e11550dd0fb576d5176b758f8f8b5"
+  integrity sha512-MdTROOojxod78CEv22rIA69o7crMPLnVZPefuDLt/WepXqJwgiSu8Xxq+H36x0Jj3YGc7lOglI2vPJ2GhoOybw==
+  dependencies:
+    backbone "^1.4.0"
+    jquery "^3.4.1"
+    lunr "^2.3.6"
+    underscore "^1.9.1"
+
+typedoc@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.15.0.tgz#21eaf4db41cf2797bad027a74f2a75cd08ae0c2d"
+  integrity sha512-NOtfq5Tis4EFt+J2ozhVq9RCeUnfEYMFKoU6nCXCXUULJz1UQynOM+yH3TkfZCPLzigbqB0tQYGVlktUWweKlw==
+  dependencies:
+    "@types/minimatch" "3.0.3"
+    fs-extra "^8.1.0"
+    handlebars "^4.1.2"
+    highlight.js "^9.15.8"
+    lodash "^4.17.15"
+    marked "^0.7.0"
+    minimatch "^3.0.0"
+    progress "^2.0.3"
+    shelljs "^0.8.3"
+    typedoc-default-themes "^0.6.0"
+    typescript "3.5.x"
+
 typedoc@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.12.0.tgz#c5d606f52af29d841658e18d9faa1a72acf0e270"
@@ -6674,14 +6772,14 @@ typescript@3.0.x, typescript@~3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
 
-typescript@~2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-
-typescript@~3.5.1:
+typescript@3.5.x, typescript@~3.5.1:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+
+typescript@~2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
 uglify-js@^2.6, uglify-js@^2.8.27:
   version "2.8.29"
@@ -6715,6 +6813,11 @@ ultron@1.0.x:
 umask@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
+
+underscore@>=1.8.3, underscore@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
+  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
 
 union-value@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6678,6 +6678,11 @@ typescript@~2.9.2:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
+typescript@~3.5.1:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+
 uglify-js@^2.6, uglify-js@^2.8.27:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"


### PR DESCRIPTION
This adds some helper utilities for getting, updating, and listening to data in the datastore.

* There are three type aliases for specifying `TableLocation`, `RecordLocation`, and `FieldLocation`.
* There are utility functions that allow you to get/update/listen-to tables, records, and fields. This makes a total of nine utility functions.
* Adds a `Datastore.withTransaction` helper which wraps a callback in `beginTransaction`/`endTransaction`.

These are currently statics in a `Datastore` namespace, since that's how I've been using them in JLab, but some of them could be moved onto the datastore class itself.