### PR TITLE
Add more type safety to datastore get

### DIFF
--- a/packages/datastore/src/table.ts
+++ b/packages/datastore/src/table.ts
@@ -42,7 +42,7 @@ class Table<S extends Schema> implements IIterable<Record<S>> {
    *
    * @returns A new datastore table.
    */
-  static create<U extends Schema>(schema: U, context: Datastore.Context): Table<U> {
+  static create<U extends Schema>(schema: U, context: Datastore.Context<U>): Table<U> {
     return new Table<U>(schema, context);
   }
 
@@ -57,7 +57,7 @@ class Table<S extends Schema> implements IIterable<Record<S>> {
    *
    * @returns A new datastore table.
    */
-  static recreate<U extends Schema>(schema: U, context: Datastore.Context, records: IterableOrArrayLike<Record<U>>): Table<U> {
+  static recreate<U extends Schema>(schema: U, context: Datastore.Context<U>, records: IterableOrArrayLike<Record<U>>): Table<U> {
     return new Table<U>(schema, context, records);
   }
 
@@ -213,7 +213,7 @@ class Table<S extends Schema> implements IIterable<Record<S>> {
    *
    * @param context - The datastore context.
    */
-  private constructor(schema: S, context: Datastore.Context, records?: IterableOrArrayLike<Record<S>>) {
+  private constructor(schema: S, context: Datastore.Context<S>, records?: IterableOrArrayLike<Record<S>>) {
     this.schema = schema;
     this._context = context;
     if (records) {
@@ -221,7 +221,7 @@ class Table<S extends Schema> implements IIterable<Record<S>> {
     }
   }
 
-  private _context: Datastore.Context;
+  private _context: Datastore.Context<S>;
   private _records = new BPlusTree<Record<S>>(Private.recordCmp);
 }
 
@@ -341,7 +341,7 @@ namespace Private {
    * @returns A new record with the update applied.
    */
   export
-  function applyUpdate<S extends Schema>(schema: S, record: Record<S>, update: Record.Update<S>, context: Datastore.Context): Record<S> {
+  function applyUpdate<S extends Schema>(schema: S, record: Record<S>, update: Record.Update<S>, context: Datastore.Context<S>): Record<S> {
     // Fetch the version and store id.
     let version = context.version;
     let storeId = context.storeId;

--- a/packages/datastore/tests/src/datastore.spec.ts
+++ b/packages/datastore/tests/src/datastore.spec.ts
@@ -10,7 +10,7 @@ import {
 } from 'chai';
 
 import {
-  Datastore, Fields, ListField, RegisterField, TextField
+  Datastore, Fields, ListField, RegisterField, TextField, Schema
 } from '@phosphor/datastore';
 
 import {
@@ -78,21 +78,21 @@ class LoggingMessageHandler implements IMessageHandler {
   processMessage(msg: Message): void {
     switch(msg.type) {
     case 'datastore-transaction':
-      this.transactions.push((msg as Datastore.TransactionMessage).transaction);
+      this.transactions.push((msg as Datastore.TransactionMessage<Schema>).transaction);
       break;
     default:
       throw Error('Unexpected message');
       break;
     }
   }
-  transactions: Datastore.Transaction[] = [];
+  transactions: Datastore.Transaction<Schema>[] = [];
 }
 
 describe('@phosphor/datastore', () => {
 
   describe('Datastore', () => {
 
-    let datastore: Datastore;
+    let datastore: Datastore<[typeof schema1, typeof schema2]>;
     let broadcastHandler: LoggingMessageHandler;
     const DATASTORE_ID = 1234;
     beforeEach(() => {

--- a/packages/datastore/tests/src/table.spec.ts
+++ b/packages/datastore/tests/src/table.spec.ts
@@ -45,7 +45,7 @@ let schema: TestSchema = {
 /**
  * Remove readonly guards from Context for testing purposes.
  */
-type MutableContext = { -readonly [K in keyof Datastore.Context]: Datastore.Context[K] };
+type MutableContext = { -readonly [K in keyof Datastore.Context<TestSchema>]: Datastore.Context<TestSchema>[K] };
 
 describe('@phosphor/datastore', () => {
 


### PR DESCRIPTION
This PR makes the datastore  class generic with respect to the schemas it was created with. This means that the `get` method now can verify that the schema you pass is  of the same type as the schemas you created the store with.


For example, in the code below, `d.get(s2)` will fail, because it has a different type than `s`. We need the `<const>` type modifier so it types each `id` as  the constant string instead of just a string.


```typescript
const s = <const>{
  id: "dfd",
  fields: {
    test: new ListField()
  }
};

const s2 = <const>{
  id: "dfd1",
  fields: {
    test: new ListField()
  }
};

const d = Datastore.create({ schemas: [s], id: 0 });

d.get(s2);
d.get(s);
```

<img width="1301" alt="Screen Shot 2019-08-26 at 8 38 35 AM" src="https://user-images.githubusercontent.com/1186124/63692563-f5face80-c7df-11e9-83ae-936371c408b9.png">


@vidartf I think you mentioned wanting  something like this in one of our earlier meetings, if I am not mistaken.

cc/ @ian-r-rose  @jasongrout 

See https://github.com/microsoft/TypeScript/issues/20965 for a discussion of  how to get the type of an array, using `T[number]`