### PR TITLE
Handle long splices for textfield and listfield.

### DIFF
--- a/packages/datastore/src/listfield.ts
+++ b/packages/datastore/src/listfield.ts
@@ -345,8 +345,8 @@ namespace Private {
     let ids = createTriplexIds(values.length, version, storeId, lower, upper);
 
     // Apply the splice to the ids and values.
-    let removedIds = metadata.ids.splice(index, count, ...ids);
-    let removedValues = array.splice(index, count, ...values);
+    let removedIds = spliceArray(metadata.ids, index, count, ids);
+    let removedValues = spliceArray(array, index, count, values);
 
     // Create the change object.
     let change = { index, removed: removedValues, inserted: values };
@@ -411,10 +411,10 @@ namespace Private {
         let { index, ids, values } = chunks.pop()!;
 
         // Insert the identifiers into the metadata.
-        metadata.ids.splice(index, 0, ...ids);
+        spliceArray(metadata.ids, index, 0, ids);
 
         // Insert the values into the array.
-        value.splice(index, 0, ...values);
+        spliceArray(value, index, 0, values);
 
         // Add the change part to the change array.
         change.push({ index, removed: [], inserted: values });
@@ -609,5 +609,41 @@ namespace Private {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Splice data into an array.
+   *
+   * #### Notes
+   * This is intentionally similar to Array.splice, but chunks the splices into
+   * multiple splices so that it does not crash if the number of spliced IDs
+   * is greater than the maximum number of arguments for a function.
+   *
+   * @param arr - the array on which to perform the splice.
+   *
+   * @param start - the start index for the splice.
+   *
+   * @param deleteCount - how many indices to remove.
+   *
+   * @param items - the items to splice into the array.
+   *
+   * @returns an array of the deleted elements.
+   */
+  function spliceArray<T>(arr: T[], start: number, deleteCount?: number, items?: ReadonlyArray<T>): ReadonlyArray<T> {
+    if (!items) {
+      return arr.splice(start, deleteCount);
+    }
+    let size = 100000;
+    if (items.length < size) {
+      return arr.splice(start, deleteCount || 0, ...items);
+    }
+    let deleted = arr.splice(start, deleteCount);
+    let n = Math.floor(items.length / size);
+    let idx = 0;
+    for (let i = 0; i < n; i++, idx += size) {
+      arr.splice(idx, 0, ...items.slice(idx, size));
+    }
+    arr.splice(idx, 0, ...items.slice(idx));
+    return deleted;
   }
 }

--- a/packages/datastore/src/textfield.ts
+++ b/packages/datastore/src/textfield.ts
@@ -352,7 +352,7 @@ namespace Private {
     let ids = createTriplexIds(text.length, version, storeId, lower, upper);
 
     // Apply the splice to the ids.
-    let removedIds = metadata.ids.splice(index, count, ...ids);
+    let removedIds = spliceArray(metadata.ids, index, count, ids);
 
     // Compute the removed text.
     let removedText = value.slice(index, index + count);
@@ -442,7 +442,7 @@ namespace Private {
         let { index, ids, text } = chunks.pop()!;
 
         // Insert the identifiers into the metadata.
-        metadata.ids.splice(index, 0, ...ids);
+        spliceArray(metadata.ids, index, 0, ids);
 
         // Insert the text into the value.
         value = value.slice(0, index) + text + value.slice(index);
@@ -640,5 +640,41 @@ namespace Private {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Splice data into an array.
+   *
+   * #### Notes
+   * This is intentionally similar to Array.splice, but chunks the splices into
+   * multiple splices so that it does not crash if the number of spliced IDs
+   * is greater than the maximum number of arguments for a function.
+   *
+   * @param arr - the array on which to perform the splice.
+   *
+   * @param start - the start index for the splice.
+   *
+   * @param deleteCount - how many indices to remove.
+   *
+   * @param items - the items to splice into the array.
+   *
+   * @returns an array of the deleted elements.
+   */
+  function spliceArray<T>(arr: T[], start: number, deleteCount?: number, items?: ReadonlyArray<T>): ReadonlyArray<T> {
+    if (!items) {
+      return arr.splice(start, deleteCount);
+    }
+    let size = 100000;
+    if (items.length < size) {
+      return arr.splice(start, deleteCount || 0, ...items);
+    }
+    let deleted = arr.splice(start, deleteCount);
+    let n = Math.floor(items.length / size);
+    let idx = 0;
+    for (let i = 0; i < n; i++, idx += size) {
+      arr.splice(idx, 0, ...items.slice(idx, size));
+    }
+    arr.splice(idx, 0, ...items.slice(idx));
+    return deleted;
   }
 }

--- a/packages/datastore/tests/src/listfield.spec.ts
+++ b/packages/datastore/tests/src/listfield.spec.ts
@@ -135,6 +135,26 @@ describe('@phosphor/datastore', () => {
         expect(patch[1].insertedIds.length).to.equal(splice2.values.length);
       });
 
+      it('should accept long splices', () => {
+        let previous = field.createValue();
+        let values: number[] = [];
+        values.fill(0, 0, 1000000);
+        let metadata = field.createMetadata();
+        let splice = {
+          index: 0,
+          remove: 0,
+          values
+        };
+        let { value } = field.applyUpdate({
+          previous,
+          update: [splice],
+          metadata,
+          version: 1,
+          storeId: 1
+        });
+        expect(value).to.eql(values);
+      });
+
     });
 
     describe('applyPatch', () => {

--- a/packages/datastore/tests/src/textfield.spec.ts
+++ b/packages/datastore/tests/src/textfield.spec.ts
@@ -130,6 +130,25 @@ describe('@phosphor/datastore', () => {
         expect(patch[1].insertedIds.length).to.equal(splice2.text.length);
       });
 
+      it('should accept long splices', () => {
+        let previous = field.createValue();
+        let text = 'a'.repeat(1000000);
+        let metadata = field.createMetadata();
+        let splice = {
+          index: 0,
+          remove: 0,
+          text
+        };
+        let { value } = field.applyUpdate({
+          previous,
+          update: [splice],
+          metadata,
+          version: 1,
+          storeId: 1
+        });
+        expect(value).to.equal(text);
+      });
+
     });
 
     describe('applyPatch', () => {

--- a/packages/datastore/tests/tsconfig.json
+++ b/packages/datastore/tests/tsconfig.json
@@ -9,7 +9,7 @@
     "moduleResolution": "node",
     "target": "ES5",
     "outDir": "./build",
-    "lib": ["ES5", "DOM"],
+    "lib": ["ES6", "DOM"],
     "types": ["chai", "mocha"]
   },
   "include": ["src/*"]


### PR DESCRIPTION
Using `Array.splice` when the to-be-spliced values can run into browser limits for the most arguments allowed to be passed to a variadic function. This can happen especially when initializing a large text field (i.e., a few hundred thousand characters).

This PR implements an internal utility for splitting up large splices, getting around the browser limitations on the number of function args. The chunk size 100000 comes from some experimentation with Chrome and Firefox.

Now, text files of this size also start running into problems with ID sizes, which we still need to solve. But this is a mostly orthogonal problem.