### PR TITLE
implement per-cell metadata. simplify the renderer map.

### DIFF
--- a/examples/example-datagrid/src/index.ts
+++ b/examples/example-datagrid/src/index.ts
@@ -257,14 +257,14 @@ function main(): void {
   });
 
   let grid3 = new DataGrid({ stretchLastColumn: true });
-  grid3.cellRenderers.set('body', {}, fgColorFloatRenderer);
+  grid3.cellRenderers.update({ 'body': fgColorFloatRenderer });
   grid3.dataModel = model3;
   grid3.keyHandler = new BasicKeyHandler();
   grid3.mouseHandler = new BasicMouseHandler();
   grid3.selectionModel = new BasicSelectionModel({ dataModel: model3 });
 
   let grid4 = new DataGrid({ style: lightSelectionStyle });
-  grid4.cellRenderers.set('body', {}, bgColorFloatRenderer);
+  grid4.cellRenderers.update({ 'body': bgColorFloatRenderer });
   grid4.dataModel = model4;
   grid4.keyHandler = new BasicKeyHandler();
   grid4.mouseHandler = new BasicMouseHandler();

--- a/packages/datagrid/src/cellrenderer.ts
+++ b/packages/datagrid/src/cellrenderer.ts
@@ -1,5 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2017, PhosphorJS Contributors
+| Copyright (c) 2014-2019, PhosphorJS Contributors
 |
 | Distributed under the terms of the BSD 3-Clause License.
 |
@@ -44,26 +44,7 @@ abstract class CellRenderer {
    *
    * The renderer **must not** draw outside the cell bounding height.
    */
-  abstract paint(gc: GraphicsContext, config: CellRenderer.ICellConfig): void;
-
-  /**
-   * Prepare the graphics context for drawing a column of cells.
-   *
-   * @param gc - The graphics context to prepare.
-   *
-   * @param config - The configuration data for the column.
-   *
-   * #### Notes
-   * This method is called just before the grid renders the cells in
-   * a column. It allows the renderer an opportunity to set defaults
-   * on the `gc` or pre-compute column render state. This can reduce
-   * the need for costly `gc` state changes when painting each cell.
-   *
-   * The renderer **must not** draw to the `gc` in this method.
-   *
-   * The default implementation is a no-op.
-   */
-  prepare(gc: GraphicsContext, config: CellRenderer.IColumnConfig): void { }
+  abstract paint(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
 }
 
 
@@ -73,41 +54,10 @@ abstract class CellRenderer {
 export
 namespace CellRenderer {
   /**
-   * An object which holds the configuration data for a column.
-   */
-  export
-  interface IColumnConfig {
-    /**
-     * The X position of the column, in viewport coordinates.
-     */
-    readonly x: number;
-
-    /**
-     * The width of the column, in viewport pixels.
-     */
-    readonly width: number;
-
-    /**
-     * The region for the column.
-     */
-    readonly region: DataModel.CellRegion;
-
-    /**
-     * The column index.
-     */
-    readonly column: number;
-
-    /**
-     * The metadata for the column.
-     */
-    readonly metadata: DataModel.Metadata;
-  }
-
-  /**
    * An object which holds the configuration data for a cell.
    */
   export
-  interface ICellConfig {
+  type CellConfig = {
     /**
      * The X position of the cell rectangle, in viewport coordinates.
      */
@@ -144,15 +94,15 @@ namespace CellRenderer {
     readonly column: number;
 
     /**
-     * The metadata for the column.
-     */
-    readonly metadata: DataModel.Metadata;
-
-    /**
-     * The data value for the cell.
+     * The value for the cell.
      */
     readonly value: any;
-  }
+
+    /**
+     * The metadata for the cell.
+     */
+    readonly metadata: DataModel.Metadata;
+  };
 
   /**
    * A type alias for a cell renderer config function.
@@ -160,7 +110,7 @@ namespace CellRenderer {
    * This type is used to compute a value from a cell config object.
    */
   export
-  type ConfigFunc<T> = (config: ICellConfig) => T;
+  type ConfigFunc<T> = (config: CellConfig) => T;
 
   /**
    * A type alias for a cell renderer config option.
@@ -180,7 +130,7 @@ namespace CellRenderer {
    * @returns The resolved value for the option.
    */
   export
-  function resolveOption<T>(option: ConfigOption<T>, config: ICellConfig): T {
+  function resolveOption<T>(option: ConfigOption<T>, config: CellConfig): T {
     return typeof option === 'function' ? option(config) : option;
   }
 }

--- a/packages/datagrid/src/datamodel.ts
+++ b/packages/datagrid/src/datamodel.ts
@@ -1,5 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2017, PhosphorJS Contributors
+| Copyright (c) 2014-2019, PhosphorJS Contributors
 |
 | Distributed under the terms of the BSD 3-Clause License.
 |
@@ -59,36 +59,34 @@ abstract class DataModel {
    *
    * @param column - The column index of the cell of interest.
    *
-   * @param returns - The data value for the specified cell.
+   * @param returns The data value for the specified cell.
    *
    * #### Notes
+   * The returned data should be treated as immutable.
+   *
    * This method is called often, and so should be efficient.
    */
   abstract data(region: DataModel.CellRegion, row: number, column: number): any;
 
   /**
-   * Get the metadata for a column in the data model.
+   * Get the metadata for a cell in the data model.
    *
    * @param region - The cell region of interest.
    *
-   * @param column - The index of the column of interest.
+   * @param row - The row index of the cell of interest.
    *
-   * @returns The metadata for the column.
+   * @param column - The column index of the cell of interest.
+   *
+   * @returns The metadata for the specified cell.
    *
    * #### Notes
    * The returned metadata should be treated as immutable.
-   *
-   * Models which support columnar data may reimplement this method to
-   * return the metadata for a column.
-   *
-   * The metadata can be used by custom cell renderers and cell editors
-   * to customize handling of specific cell data types.
    *
    * This method is called often, and so should be efficient.
    *
    * The default implementation returns `{}`.
    */
-  metadata(region: DataModel.CellRegion, column: number): DataModel.Metadata {
+  metadata(region: DataModel.CellRegion, row: number, column: number): DataModel.Metadata {
     return DataModel.emptyMetadata;
   }
 

--- a/packages/datagrid/src/graphicscontext.ts
+++ b/packages/datagrid/src/graphicscontext.ts
@@ -1,5 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2017, PhosphorJS Contributors
+| Copyright (c) 2014-2019, PhosphorJS Contributors
 |
 | Distributed under the terms of the BSD 3-Clause License.
 |

--- a/packages/datagrid/src/index.ts
+++ b/packages/datagrid/src/index.ts
@@ -1,5 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2017, PhosphorJS Contributors
+| Copyright (c) 2014-2019, PhosphorJS Contributors
 |
 | Distributed under the terms of the BSD 3-Clause License.
 |

--- a/packages/datagrid/src/jsonmodel.ts
+++ b/packages/datagrid/src/jsonmodel.ts
@@ -1,5 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2017, PhosphorJS Contributors
+| Copyright (c) 2014-2019, PhosphorJS Contributors
 |
 | Distributed under the terms of the BSD 3-Clause License.
 |
@@ -62,22 +62,6 @@ class JSONModel extends DataModel {
   }
 
   /**
-   * Get the metadata for a column in the data model.
-   *
-   * @param region - The cell region of interest.
-   *
-   * @param column - The index of the column of interest.
-   *
-   * @returns The metadata for the column.
-   */
-  metadata(region: DataModel.CellRegion, column: number): DataModel.Metadata {
-    if (region === 'body' || region === 'column-header') {
-      return this._bodyFields[column];
-    }
-    return this._headerFields[column];
-  }
-
-  /**
    * Get the data value for a cell in the data model.
    *
    * @param region - The cell region of interest.
@@ -93,7 +77,7 @@ class JSONModel extends DataModel {
    */
   data(region: DataModel.CellRegion, row: number, column: number): any {
     // Set up the field and value variables.
-    let field: JSONModel.IField;
+    let field: JSONModel.Field;
     let value: any;
 
     // Look up the field and value for the region.
@@ -129,9 +113,27 @@ class JSONModel extends DataModel {
     return missing ? null : value;
   }
 
+  /**
+   * Get the metadata for a cell in the data model.
+   *
+   * @param region - The cell region of interest.
+   *
+   * @param row - The row index of the cell of of interest.
+   *
+   * @param column - The column index of the cell of interest.
+   *
+   * @returns The metadata for the cell.
+   */
+  metadata(region: DataModel.CellRegion, row: number, column: number): DataModel.Metadata {
+    if (region === 'body' || region === 'column-header') {
+      return this._bodyFields[column];
+    }
+    return this._headerFields[column];
+  }
+
   private _data: JSONModel.DataSource;
-  private _bodyFields: JSONModel.IField[];
-  private _headerFields: JSONModel.IField[];
+  private _bodyFields: JSONModel.Field[];
+  private _headerFields: JSONModel.Field[];
   private _missingValues: Private.MissingValuesMap | null;
 }
 
@@ -149,7 +151,7 @@ namespace JSONModel {
    * https://specs.frictionlessdata.io/table-schema/
    */
   export
-  interface IField {
+  type Field = {
     /**
      * The name of the column.
      *
@@ -180,7 +182,7 @@ namespace JSONModel {
     // description?: string;
     // constraints?: IConstraints;
     // rdfType?: string;
-  }
+  };
 
   /**
    * An object when specifies the schema for a data model.
@@ -190,13 +192,13 @@ namespace JSONModel {
    * https://specs.frictionlessdata.io/table-schema/
    */
   export
-  interface ISchema {
+  type Schema = {
     /**
      * The fields which describe the data model columns.
      *
      * Primary key fields are rendered as row header columns.
      */
-    readonly fields: IField[];
+    readonly fields: Field[];
 
     /**
      * The values to treat as "missing" data.
@@ -214,7 +216,7 @@ namespace JSONModel {
 
     // TODO want/need support for this?
     // foreignKeys?: IForeignKey[];
-  }
+  };
 
   /**
    * A type alias for a data source for a JSON data model.
@@ -236,7 +238,7 @@ namespace JSONModel {
      *
      * The schema should be treated as an immutable object.
      */
-    schema: ISchema;
+    schema: Schema;
 
     /**
      * The data source for the data model.
@@ -256,23 +258,23 @@ namespace Private {
    * An object which holds the results of splitting schema fields.
    */
   export
-  interface ISplitFieldsResult {
+  type SplitFieldsResult = {
     /**
      * The non-primary key fields to use for the grid body.
      */
-    bodyFields: JSONModel.IField[];
+    bodyFields: JSONModel.Field[];
 
     /**
      * The primary key fields to use for the grid headers.
      */
-    headerFields: JSONModel.IField[];
-  }
+    headerFields: JSONModel.Field[];
+  };
 
   /**
    * Split the schema fields into header and body fields.
    */
   export
-  function splitFields(schema: JSONModel.ISchema): ISplitFieldsResult {
+  function splitFields(schema: JSONModel.Schema): SplitFieldsResult {
     // Normalize the primary keys.
     let primaryKeys: string[];
     if (schema.primaryKey === undefined) {
@@ -284,8 +286,8 @@ namespace Private {
     }
 
     // Separate the fields for the body and header.
-    let bodyFields: JSONModel.IField[] = [];
-    let headerFields: JSONModel.IField[] = [];
+    let bodyFields: JSONModel.Field[] = [];
+    let headerFields: JSONModel.Field[] = [];
     for (let field of schema.fields) {
       if (primaryKeys.indexOf(field.name) === -1) {
         bodyFields.push(field);
@@ -310,7 +312,7 @@ namespace Private {
    * This returns `null` if there are no missing values.
    */
   export
-  function createMissingMap(schema: JSONModel.ISchema): MissingValuesMap | null {
+  function createMissingMap(schema: JSONModel.Schema): MissingValuesMap | null {
     // Bail early if there are no missing values.
     if (!schema.missingValues || schema.missingValues.length === 0) {
       return null;

--- a/packages/datagrid/src/renderermap.ts
+++ b/packages/datagrid/src/renderermap.ts
@@ -34,7 +34,7 @@ class RendererMap {
    *
    * @param fallback - The renderer of last resort.
    */
-  constructor(values: RendererMap.Map = {}, fallback?: CellRenderer) {
+  constructor(values: RendererMap.Values = {}, fallback?: CellRenderer) {
     this._values = { ...values };
     this._fallback = fallback || new TextRenderer();
   }
@@ -81,14 +81,14 @@ class RendererMap {
    * #### Notes
    * This method always emits the `changed` signal.
    */
-  update(values: RendererMap.Map = {}, fallback?: CellRenderer): void {
+  update(values: RendererMap.Values = {}, fallback?: CellRenderer): void {
     this._values = { ...this._values, ...values };
     this._fallback = fallback || this._fallback;
     this._changed.emit(undefined);
   }
 
-  private _fallback: CellRenderer
-  private _values: RendererMap.Map;
+  private _fallback: CellRenderer;
+  private _values: RendererMap.Values;
   private _changed = new Signal<this, void>(this);
 }
 
@@ -102,17 +102,13 @@ namespace RendererMap {
    * A type alias for a cell renderer resolver function.
    */
   export
-  type Resolver = (config: CellRenderer.CellConfig) => CellRenderer | undefined;
+  type Resolver = CellRenderer.ConfigFunc<CellRenderer | undefined>;
 
   /**
-   * A type alias for a `RendererMap` value type.
+   * A type alias for a `RendererMap` values type.
    */
   export
-  type Value = Resolver | CellRenderer | undefined;
-
-  /**
-   * A type alias for a `RendererMap` map type.
-   */
-  export
-  type Map = { [R in DataModel.CellRegion]?: Value };
+  type Values = {
+    [R in DataModel.CellRegion]?: Resolver | CellRenderer | undefined;
+  };
 }

--- a/packages/datagrid/src/renderermap.ts
+++ b/packages/datagrid/src/renderermap.ts
@@ -1,14 +1,10 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2017, PhosphorJS Contributors
+| Copyright (c) 2014-2019, PhosphorJS Contributors
 |
 | Distributed under the terms of the BSD 3-Clause License.
 |
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
-import {
-  ArrayExt
-} from '@phosphor/algorithm';
-
 import {
   ISignal, Signal
 } from '@phosphor/signaling';
@@ -21,132 +17,79 @@ import {
   DataModel
 } from './datamodel';
 
+import {
+  TextRenderer
+} from './textrenderer';
+
 
 /**
- * An object which manages a mapping of cell renderers.
- *
- * #### Notes
- * This class is used to configure cell renderers for a data grid.
+ * A class which manages the mapping of cell renderers.
  */
 export
 class RendererMap {
   /**
    * Construct a new renderer map.
    *
-   * @param options - The options for initializing the map.
+   * @param values - The initial values for the map.
+   *
+   * @param fallback - The renderer of last resort.
    */
-  constructor(options: RendererMap.IOptions = {}) {
-    this._ranks = Private.createRankMap(options.priority || []);
+  constructor(values: RendererMap.Map = {}, fallback?: CellRenderer) {
+    this._values = { ...values };
+    this._fallback = fallback || new TextRenderer();
   }
 
   /**
-   * A signal emitted when the map contents are changed.
+   * A signal emitted when the renderer map has changed.
    */
   get changed(): ISignal<this, void> {
     return this._changed;
   }
 
   /**
-   * Get the cell renderer to use for the given region and metadata.
+   * Get the cell renderer to use for the given cell config.
    *
-   * @param region - The cell region of interest.
+   * @param config - The cell config of interest.
    *
-   * @param metadata - The data model metadata for the region.
-   *
-   * @returns The best matching cell renderer, or `undefined`.
-   *
-   * #### Notes
-   * Non-string metadata values are ignored.
+   * @returns The renderer to use for the cell.
    */
-  get(region: DataModel.CellRegion, metadata: DataModel.Metadata): CellRenderer | undefined {
-    // Iterate through the map entries to find the best cell renderer.
-    for (let i = 0, n = this._entries.length; i < n; ++i) {
-      // Create the key for the current entry.
-      let key = this._entries[i].createKey(metadata);
+  get(config: CellRenderer.CellConfig): CellRenderer {
+    // Fetch the renderer from the values map.
+    let renderer = this._values[config.region];
 
-      // Skip the entry if no key could be generated.
-      if (key === undefined) {
-        continue;
-      }
-
-      // Prepend the region to the key.
-      key = `${region}|${key}`;
-
-      // Look up the renderer for the generated key.
-      let renderer = this._renderers[key];
-
-      // If the renderer exists, it is the best match.
-      if (renderer !== undefined) {
-        return renderer;
+    // Execute a resolver function if necessary.
+    if (typeof renderer === 'function') {
+      try {
+        renderer = renderer(config);
+      } catch (err) {
+        renderer = undefined;
+        console.error(err);
       }
     }
 
-    // Return `undefined` to indicate no match.
-    return undefined;
+    // Return the renderer or the fallback.
+    return renderer || this._fallback;
   }
 
   /**
-   * Set the cell renderer for a particular region and metadata.
+   * Update the renderer map with new values
    *
-   * @param region - The cell region of interest.
+   * @param values - The updated values for the map.
    *
-   * @param metadata - The metadata to match against the model.
-   *
-   * @param renderer - The cell renderer to set in the map.
+   * @param fallback - The renderer of last resort.
    *
    * #### Notes
-   * The keys and values in the supplied metadata are matched against
-   * the metadata supplied by the data model. The given metadata must
-   * be an exact matching subset of the model metadata in order for
-   * there to be a match.
-   *
-   * Matches are ranked according the number of matched values, with
-   * ties broken based on the priorty order given to the constructor.
-   *
-   * Non-string metadata values are ignored.
+   * This method always emits the `changed` signal.
    */
-  set(region: DataModel.CellRegion, metadata: DataModel.Metadata, renderer: CellRenderer): void {
-    // Create a new map entry for the metadata.
-    let entry = Private.MapEntry.create(metadata, this._ranks);
-
-    // Find the insert location for the entry.
-    let i = ArrayExt.lowerBound(this._entries, entry, (a, b) => {
-      return Private.MapEntry.cmp(a, b, this._ranks);
-    });
-
-    // Add the entry to the array if needed.
-    if (i === this._entries.length) {
-      this._entries.push(entry);
-    } else if (!Private.MapEntry.equal(entry, this._entries[i])) {
-      ArrayExt.insert(this._entries, i, entry);
-    }
-
-    // Create the key for the entry.
-    let key = entry.createKey(metadata);
-
-    // Prepend the region to the key.
-    key = `${region}|${key}`;
-
-    // Add the new renderer to the map.
-    this._renderers[key] = renderer;
-
-    // Emit the changed signal.
+  update(values: RendererMap.Map = {}, fallback?: CellRenderer): void {
+    this._values = { ...this._values, ...values };
+    this._fallback = fallback || this._fallback;
     this._changed.emit(undefined);
   }
 
-  /**
-   * Remove all custom cell renderers from the map.
-   */
-  clear(): void {
-    this._entries = [];
-    this._renderers = Object.create(null);
-    this._changed.emit(undefined);
-  }
-
-  private _ranks: Private.RankMap;
-  private _entries: Private.MapEntry[] = [];
+  private _fallback: CellRenderer
+  private _values: RendererMap.Map;
   private _changed = new Signal<this, void>(this);
-  private _renderers: { [key: string]: CellRenderer } = Object.create(null);
 }
 
 
@@ -156,208 +99,20 @@ class RendererMap {
 export
 namespace RendererMap {
   /**
-   * An options object for initializing a renderer map.
+   * A type alias for a cell renderer resolver function.
    */
   export
-  interface IOptions {
-    /**
-     * The priority of the metadata keys used for matching.
-     *
-     * Keys at the front of the array have a higher priority. Metadata
-     * keys which are not included in the array are ordered by locale.
-     *
-     * The default is `[]`.
-     */
-    priority?: string[];
-  }
-}
-
-
-/**
- * The namespace for the module implementation details.
- */
-namespace Private {
-  /**
-   * A type alias for a mapping of key -> rank.
-   */
-  export
-  type RankMap = { [key: string]: number };
+  type Resolver = (config: CellRenderer.CellConfig) => CellRenderer | undefined;
 
   /**
-   * Create a rank map from a priority key array.
+   * A type alias for a `RendererMap` value type.
    */
   export
-  function createRankMap(priority: string[]): RankMap {
-    let ranks: RankMap = Object.create(null);
-    for (let i = 0, n = priority.length; i < n; ++i) {
-      ranks[priority[i]] = i;
-    }
-    return ranks;
-  }
+  type Value = Resolver | CellRenderer | undefined;
 
   /**
-   * An entry in a cell renderer map.
+   * A type alias for a `RendererMap` map type.
    */
   export
-  class MapEntry {
-    /**
-     * Create a new map entry.
-     *
-     * @param metadata - The metadata which will be used as the key
-     *  for matching against the model metadata.
-     *
-     * @param ranks - The priority ranks for the metadata keys.
-     *
-     * @returns A new map entry for the given metadata key.
-     */
-    static create(metadata: DataModel.Metadata, ranks: RankMap): MapEntry {
-      // Extra the string-valued keys from the metadata.
-      let keys: string[] = [];
-      for (let key in metadata) {
-        if (typeof metadata[key] === 'string') {
-          keys.push(key);
-        }
-      }
-
-      // Sort the keys based on rank and locale.
-      keys.sort((k1, k2) => {
-        let r1 = ranks[k1];
-        let r2 = ranks[k2];
-        if (r1 !== undefined && r2 !== undefined) {
-          return r1 - r2;
-        }
-        if (r2 === undefined) {
-          return -1;
-        }
-        if (r1 === undefined) {
-          return 1;
-        }
-        return k1.localeCompare(k2);
-      });
-
-      // Create an return a new map entry.
-      return new MapEntry(keys);
-    }
-
-    /**
-     * Compare two map entries for relative ordering.
-     *
-     * @param a - The LHS map entry.
-     *
-     * @param b - The RHS map entry.
-     *
-     * @param ranks - The priority ranks for the metadata keys.
-     *
-     * @returns `< 0` if `a < b`, `> 0` if `a > b`, or `0` if `a = b`.
-     */
-    static cmp(a: MapEntry, b: MapEntry, ranks: RankMap): number {
-      // Compare first based on key length.
-      let n1 = a._keys.length;
-      let n2 = b._keys.length;
-      if (n1 !== n2) {
-        return n2 - n1;
-      }
-
-      // Compare next based on key content.
-      for (let i = 0; i < n1; ++i) {
-        // Look up the current keys.
-        let k1 = a._keys[i];
-        let k2 = b._keys[i];
-
-        // Skip if the keys are equal.
-        if (k1 === k2) {
-          continue;
-        }
-
-        // Look up the current ranks.
-        let r1 = ranks[k1];
-        let r2 = ranks[k2];
-
-        // Use rank order if possible.
-        if (r1 !== undefined && r2 !== undefined) {
-          return r1 - r2;
-        }
-
-        // Handle the case of one key having rank.
-        if (r2 === undefined) {
-          return -1;
-        }
-        if (r1 === undefined) {
-          return 1;
-        }
-
-        // Fall back to locale order.
-        return k1.localeCompare(k2);
-      }
-
-      // Otherwise, the map entries are equivalent.
-      return 0;
-    }
-
-    /**
-     * Compare two map entries for equality.
-     *
-     * @param a - The LHS map entry.
-     *
-     * @param b - The RHS map entry.
-     *
-     * @returns Whether the two entries are functionally equivalent.
-     */
-    static equal(a: MapEntry, b: MapEntry): boolean {
-      // Bail early if the keys have different length.
-      if (a._keys.length !== b._keys.length) {
-        return false;
-      }
-
-      // Test each key for equality.
-      for (let i = 0, n = a._keys.length; i < n; ++i) {
-        if (a._keys[i] !== b._keys[i]) {
-          return false;
-        }
-      }
-
-      // Otherwise, the entries are equivalent.
-      return true;
-    }
-
-    /**
-     * Create the renderer map key for a metadata object.
-     *
-     * @param metadata - The metadata supplied by the data model.
-     *
-     * @returns The key for the metadata object, or `undefined` if the
-     *   metadata is not a valid candidate match for the entry.
-     */
-    createKey(metadata: DataModel.Metadata): string | undefined {
-      // Set up the result variable.
-      let result = '';
-
-      // Loop over each key and create the value pairs.
-      for (let i = 0, n = this._keys.length; i < n; ++i) {
-        // Look up metadata value for the key.
-        let key = this._keys[i];
-        let value = metadata[key];
-
-        // Bail if the metadata value is not a string.
-        if (typeof value !== 'string') {
-          return undefined;
-        }
-
-        // Add the key/value pair to the result.
-        result += `{${key}: ${value}}`;
-      }
-
-      // Return the final key.
-      return result;
-    }
-
-    /**
-     * Construct a new map entry from ordered key names.
-     */
-    private constructor(keys: string[]) {
-      this._keys = keys;
-    }
-
-    private _keys: string[];
-  }
+  type Map = { [R in DataModel.CellRegion]?: Value };
 }

--- a/packages/datagrid/src/sectionlist.ts
+++ b/packages/datagrid/src/sectionlist.ts
@@ -1,5 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2017, PhosphorJS Contributors
+| Copyright (c) 2014-2019, PhosphorJS Contributors
 |
 | Distributed under the terms of the BSD 3-Clause License.
 |
@@ -565,7 +565,7 @@ class SectionList {
   private _count = 0;
   private _length = 0;
   private _defaultSize: number;
-  private _sections: Private.ISection[] = [];
+  private _sections: Private.Section[] = [];
 }
 
 
@@ -595,7 +595,7 @@ namespace Private {
    * An object which represents a modified section.
    */
   export
-  interface ISection {
+  type Section = {
     /**
      * The index of the section.
      *
@@ -614,13 +614,13 @@ namespace Private {
      * This is always `>= 0`.
      */
     size: number;
-  }
+  };
 
   /**
    * A comparison function for searching by offset.
    */
   export
-  function offsetCmp(section: ISection, offset: number): number {
+  function offsetCmp(section: Section, offset: number): number {
     if (offset < section.offset) {
       return 1;
     }
@@ -634,7 +634,7 @@ namespace Private {
    * A comparison function for searching by index.
    */
   export
-  function indexCmp(section: ISection, index: number): number {
+  function indexCmp(section: Section, index: number): number {
     return section.index - index;
   }
 }

--- a/packages/datagrid/src/textrenderer.ts
+++ b/packages/datagrid/src/textrenderer.ts
@@ -1,5 +1,5 @@
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2017, PhosphorJS Contributors
+| Copyright (c) 2014-2019, PhosphorJS Contributors
 |
 | Distributed under the terms of the BSD 3-Clause License.
 |
@@ -71,47 +71,9 @@ class TextRenderer extends CellRenderer {
    *
    * @param config - The configuration data for the cell.
    */
-  paint(gc: GraphicsContext, config: CellRenderer.ICellConfig): void {
+  paint(gc: GraphicsContext, config: CellRenderer.CellConfig): void {
     this.drawBackground(gc, config);
     this.drawText(gc, config);
-  }
-
-  /**
-   * Prepare the graphics context for drawing a column of cells.
-   *
-   * @param gc - The graphics context to prepare.
-   *
-   * @param row - The index of the first row to be rendered.
-   *
-   * @param col - The index of the column to be rendered.
-   *
-   * @param field - The field descriptor for the column, or `null`.
-   */
-  prepare(gc: GraphicsContext, config: CellRenderer.IColumnConfig): void {
-    // Look up the default state from the renderer.
-    let { font, textColor, backgroundColor, horizontalAlignment } = this;
-
-    // Set up the default font.
-    if (font && typeof font === 'string') {
-      gc.font = font;
-    }
-
-    // Set up the default fill style.
-    if (backgroundColor && typeof backgroundColor === 'string') {
-      gc.fillStyle = backgroundColor;
-    } else if (textColor && typeof textColor === 'string') {
-      gc.fillStyle = textColor;
-    }
-
-    // Set up the default text alignment.
-    if (typeof horizontalAlignment === 'string') {
-      gc.textAlign = horizontalAlignment;
-    } else {
-      gc.textAlign = 'left';
-    }
-
-    // Set up the default text baseline.
-    gc.textBaseline = 'bottom';
   }
 
   /**
@@ -121,7 +83,7 @@ class TextRenderer extends CellRenderer {
    *
    * @param config - The configuration data for the cell.
    */
-  drawBackground(gc: GraphicsContext, config: CellRenderer.ICellConfig): void {
+  drawBackground(gc: GraphicsContext, config: CellRenderer.CellConfig): void {
     // Resolve the background color for the cell.
     let color = CellRenderer.resolveOption(this.backgroundColor, config);
 
@@ -142,7 +104,7 @@ class TextRenderer extends CellRenderer {
    *
    * @param config - The configuration data for the cell.
    */
-  drawText(gc: GraphicsContext, config: CellRenderer.ICellConfig): void {
+  drawText(gc: GraphicsContext, config: CellRenderer.CellConfig): void {
     // Resolve the font for the cell.
     let font = CellRenderer.resolveOption(this.font, config);
 


### PR DESCRIPTION
cc @blink1073 @afshin @jasongrout @ellisonbg @SylvainCorlay 

This updates the `DataModel` to allow per-cell `metadata`. I profiled this with the datagrid example app, and found negligible difference in rendering times. This change will make it easier to build a spreadsheet model, where the easiest way to store per-cell type/styling/formatting info is with per-cell metadata.

I also updated the logic of the `RendererMap`. My initial implementation of matching based on metadata string values was too much magic (IMO) and was unnecessarily restrictive. The new version is much simpler and has much more flexibility. It allows for arbitrary resolution logic by the end user.

The `prepare` method was removed from `CellRenderer` because it was called once per column. This matched the mental model that metadata was per-column rather than per-cell. The idea was that a renderer could pre-set GC properties which are common for a column. This turned out to not be necessary because the GC is caching property changes automatically anyway. Getting rid of that method simplifies the mental model.

There are a few other unrelated updates to copyright dates and changing `interface` to `type` where it makes sense. 