### PR TITLE
Adds a "pass thru" virtual element

### DIFF
--- a/packages/virtualdom/package.json
+++ b/packages/virtualdom/package.json
@@ -35,6 +35,9 @@
     "docs": "typedoc --options tdoptions.json src",
     "test": "npm run test:firefox",
     "test:chrome": "cd tests && karma start --browsers=Chrome",
+    "test:chrome-headless": "cd tests && karma start --browsers=ChromeHeadless",
+    "test:debug": "cd tests && karma start --browsers=Chrome --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
+    "test:debug:chrome-headless": "cd tests && karma start  --browsers=ChromeHeadless --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
     "test:firefox": "cd tests && karma start --browsers=Firefox",
     "test:ie": "cd tests && karma start --browsers=IE",
     "watch": "tsc --build --watch"

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -979,8 +979,10 @@ namespace VirtualDOM {
    *
    * If virtual diffing is desired, use the `render` function instead.
    */
-  export
-  function realize(node: VirtualElement): HTMLElement {
+  export function realize(node: VirtualText): Text;
+  export function realize(node: VirtualElement): HTMLElement;
+  export function realize(node: VirtualElementPass): HTMLElement;
+  export function realize(node: VirtualNode): HTMLElement | Text {
     return Private.createDOMNode(node);
   }
 

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -1017,14 +1017,12 @@ namespace Private {
   /**
    * A weak mapping of host element to virtual DOM content.
    */
-  export
-  const hostMap = new WeakMap<HTMLElement, ReadonlyArray<VirtualNode>>();
+  export const hostMap = new WeakMap<HTMLElement, ReadonlyArray<VirtualNode>>();
 
   /**
    * Cast a content value to a content array.
    */
-  export
-  function asContentArray(value: VirtualNode | ReadonlyArray<VirtualNode> | null): ReadonlyArray<VirtualNode> {
+  export function asContentArray(value: VirtualNode | ReadonlyArray<VirtualNode> | null): ReadonlyArray<VirtualNode> {
     if (!value) {
       return [];
     }
@@ -1037,20 +1035,13 @@ namespace Private {
   /**
    * Create a new DOM element for a virtual node.
    */
-  export
-  function createDOMNode(node: VirtualText): Text;
-  export
-  function createDOMNode(node: VirtualElement): HTMLElement;
-  export
-  function createDOMNode(node: VirtualElementPass): HTMLElement;
-  export
-  function createDOMNode(node: VirtualNode): HTMLElement | Text;
-  export
-  function createDOMNode(node: VirtualNode, host: HTMLElement | null): HTMLElement | Text;
-  export
-  function createDOMNode(node: VirtualNode, host: HTMLElement | null, before: Node | null): HTMLElement | Text;
-  export
-  function createDOMNode(node: VirtualNode): HTMLElement | Text {
+  export function createDOMNode(node: VirtualText): Text;
+  export function createDOMNode(node: VirtualElement): HTMLElement;
+  export function createDOMNode(node: VirtualElementPass): HTMLElement;
+  export function createDOMNode(node: VirtualNode): HTMLElement | Text;
+  export function createDOMNode(node: VirtualNode, host: HTMLElement | null): HTMLElement | Text;
+  export function createDOMNode(node: VirtualNode, host: HTMLElement | null, before: Node | null): HTMLElement | Text;
+  export function createDOMNode(node: VirtualNode): HTMLElement | Text {
     let host = arguments[1] || null;
     const before = arguments[2] || null;
 
@@ -1088,8 +1079,7 @@ namespace Private {
    * This is the core "diff" algorithm. There is no explicit "patch"
    * phase. The host is patched at each step as the diff progresses.
    */
-  export
-  function updateContent(host: HTMLElement, oldContent: ReadonlyArray<VirtualNode>, newContent: ReadonlyArray<VirtualNode>): void {
+  export function updateContent(host: HTMLElement, oldContent: ReadonlyArray<VirtualNode>, newContent: ReadonlyArray<VirtualNode>): void {
     // Bail early if the content is identical.
     if (oldContent === newContent) {
       return;
@@ -1202,23 +1192,25 @@ namespace Private {
     }
 
     // Cleanup stale DOM
-    removeContent(host, oldCopy, newCount);
+    removeContent(host, oldCopy, newCount, true);
   }
 
-  function removeContent(host: HTMLElement, oldContent: ReadonlyArray<VirtualNode>, newCount: number) {
+  function removeContent(host: HTMLElement, oldContent: ReadonlyArray<VirtualNode>, newCount: number, _sentinel = false) {
     // Dispose of the old nodes pushed to the end of the host.
     for (let i = oldContent.length - 1; i >= newCount; --i) {
       const oldNode = oldContent[i];
+      const child = (_sentinel ? host.lastChild : host.childNodes[i]) as HTMLElement;
 
       // recursively clean up host children
       if (oldNode.type === 'text') {} else if (oldNode.type === 'passthru') {
-        oldNode.renderer.unrender!(host.lastChild as HTMLElement);
+        oldNode.renderer.unrender!(child!);
       } else {
-        removeContent((host.lastChild as HTMLElement)!, oldNode.children, 0);
+        removeContent(child!, oldNode.children, 0);
       }
 
-
-      host.removeChild(host.lastChild!);
+      if (_sentinel) {
+        host.removeChild(child!);
+      }
     }
   }
 

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -1067,40 +1067,39 @@ namespace Private {
   function createDOMNode(node: VirtualNode, host: HTMLElement | null, before: Node | null): HTMLElement | Text;
   export
   function createDOMNode(node: VirtualNode): HTMLElement | Text {
-    const host = arguments[1] || null;
+    let host = arguments[1] || null;
     const before = arguments[2] || null;
 
-    if (host) {
-      if (node.type === 'passthru') {
+    if (node.type === 'passthru') {
+      if (host) {
         // TODO: figure out how to do an "insert before" with a passthru node
         node.render(host);
       } else {
-        host.insertBefore(createDOMNode(node), before);
-      }
-
-      return host;
-    } else {
-      // Create a text node for a virtual text node.
-      if (node.type === 'text') {
-        return document.createTextNode(node.content);
-      } else if (node.type === 'passthru') {
         throw new Error("createDOMNode should not be called with only one argument on vdom nodes of type === 'passthru'");
       }
+    } else {
+      if (host) {
+        host.insertBefore(createDOMNode(node), before);
+      } else {
+        // Create a text node for a virtual text node.
+        if (node.type === 'text') {
+          return document.createTextNode(node.content);
+        }
 
-      // Create the HTML element with the specified tag.
-      let element = document.createElement(node.tag);
+        // Create the HTML element with the specified tag.
+        host = document.createElement(node.tag);
 
-      // Add the attributes for the new element.
-      addAttrs(element, node.attrs);
+        // Add the attributes for the new element.
+        addAttrs(host, node.attrs);
 
-      // Recursively populate the element with child content.
-      for (let i = 0, n = node.children.length; i < n; ++i) {
-        createDOMNode(node.children[i], element);
+        // Recursively populate the element with child content.
+        for (let i = 0, n = node.children.length; i < n; ++i) {
+          createDOMNode(node.children[i], host);
+        }
       }
-
-      // Return the populated element.
-      return element;
     }
+
+    return host;
   }
 
   /**

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -1062,12 +1062,24 @@ namespace Private {
   export
   function createDOMNode(node: VirtualNode): HTMLElement | Text;
   export
-  function createDOMNode(node: VirtualNode, host: HTMLElement): HTMLElement | Text;
+  function createDOMNode(node: VirtualNode, host: HTMLElement | null): HTMLElement | Text;
   export
-  function createDOMNode(node: VirtualNode, host: HTMLElement, before: Node | null): HTMLElement | Text;
+  function createDOMNode(node: VirtualNode, host: HTMLElement | null, before: Node | null): HTMLElement | Text;
   export
   function createDOMNode(node: VirtualNode): HTMLElement | Text {
-    if (arguments.length === 1) {
+    const host = arguments[1] || null;
+    const before = arguments[2] || null;
+
+    if (host) {
+      if (node.type === 'passthru') {
+        // TODO: figure out how to do an "insert before" with a passthru node
+        node.render(host);
+      } else {
+        host.insertBefore(createDOMNode(node), before);
+      }
+
+      return host;
+    } else {
       // Create a text node for a virtual text node.
       if (node.type === 'text') {
         return document.createTextNode(node.content);
@@ -1083,39 +1095,11 @@ namespace Private {
 
       // Recursively populate the element with child content.
       for (let i = 0, n = node.children.length; i < n; ++i) {
-        const child = node.children[i];
-
-        if (child.type === 'passthru') {
-          child.render(element);
-        } else {
-          element.appendChild(createDOMNode(child));
-        }
+        createDOMNode(node.children[i], element);
       }
 
       // Return the populated element.
       return element;
-    } else if (arguments.length === 2) {
-      const host = arguments[1];
-
-      if (node.type === 'passthru') {
-        node.render(host);
-      } else {
-        host.appendChild(createDOMNode(node));
-      }
-
-      return host;
-    } else {
-      const host = arguments[1];
-      const before = arguments[2];
-
-      if (node.type === 'passthru') {
-        // TODO: figure out how to do an "insert before" with a passthru node
-        node.render(host);
-      } else {
-        host.insertBefore(createDOMNode(node), before);
-      }
-
-      return host;
     }
   }
 

--- a/packages/virtualdom/tests/src/index.spec.ts
+++ b/packages/virtualdom/tests/src/index.spec.ts
@@ -507,25 +507,26 @@ describe('@phosphor/virtualdom', () => {
     };
 
     describe('render()', () => {
-      describe('should render child node', () => {
+      it('should render child node', () => {
         let host = document.createElement('div');
         let record: any = {};
-        let children = [h.a(), h.span(), h.div(hpass(rendererClosure(record), 'span'))];
+        let children = [h.a(), h.span(), h.div(h.div(), hpass(rendererClosure(record), 'span'), h.div())];
         VirtualDOM.render(children, host);
-        expect(host.children[2].children[0]).to.equal(record.child);
-        expect(host.children[2].children[0].className).to.equal('p-render');
+        expect(host.children[2].children[1].children[0]).to.equal(record.child);
+        expect(host.children[2].children[1].children[0].className).to.equal('p-render');
       });
 
-      describe('should cleanup child node', () => {
+      it('should cleanup child node', () => {
         let host = document.createElement('div');
         let record: any = {};
-        let children = [h.a(), h.span(), h.div(hpass(rendererClosure(record), 'span'))];
-        // first pass, render the hpass children
-        VirtualDOM.render(children, host);
 
-        children[2] = h.label();
+        // first pass, render the hpass children
+        let children0 = [h.a(), h.span(), h.div(h.div(), hpass(rendererClosure(record), 'span'), h.div())];
+        VirtualDOM.render(children0, host);
+
         // second pass, explicitly unrender the hpass children
-        VirtualDOM.render(children, host);
+        let children1 = [h.a(), h.span(), h.label()];
+        VirtualDOM.render(children1, host);
         expect(record.cleanedUp).to.equal(true);
       });
     });

--- a/packages/virtualdom/tests/src/index.spec.ts
+++ b/packages/virtualdom/tests/src/index.spec.ts
@@ -10,7 +10,7 @@ import {
 } from 'chai';
 
 import {
-  VirtualDOM, VirtualElement, VirtualText, h
+  VirtualDOM, VirtualElement, VirtualElementPass, VirtualText, h, hpass
 } from '@phosphor/virtualdom';
 
 
@@ -92,6 +92,61 @@ describe('@phosphor/virtualdom', () => {
         let children = [h.a(), h.img()];
         let vnode = new VirtualElement('div', {}, children);
         expect(vnode.children).to.equal(children);
+      });
+
+    });
+
+  });
+
+  describe('VirtualElementPass', () => {
+    let mockRenderer = {
+      render: (host: HTMLElement) => {},
+      unrender: (host: HTMLElement) =>{}
+    };
+
+    describe('#constructor()', () => {
+
+      it('should create a virtual element node', () => {
+        let vnode = new VirtualElementPass(mockRenderer, 'div', {});
+        expect(vnode).to.be.an.instanceof(VirtualElementPass);
+      });
+
+    });
+
+    describe('#type', () => {
+
+      it('should be `element`', () => {
+        let vnode = new VirtualElementPass(mockRenderer,'div', {});
+        expect(vnode.type).to.equal('passthru');
+      });
+
+    });
+
+    describe('#renderer', () => {
+
+      it('should be the element children renderer', () => {
+        let vnode = new VirtualElementPass(mockRenderer, 'div', {});
+        expect(vnode.renderer.render).to.equal(mockRenderer.render);
+        expect(vnode.renderer.unrender).to.equal(mockRenderer.unrender);
+      });
+
+    });
+
+    describe('#tag', () => {
+
+      it('should be the element tag name', () => {
+        let vnode = new VirtualElementPass(mockRenderer,'img', {});
+        expect(vnode.tag).to.equal('img');
+      });
+
+    });
+
+    describe('#attrs', () => {
+
+      it('should be the element attrs', () => {
+        let attrs = { className: 'baz' };
+        let vnode = new VirtualElementPass(mockRenderer,'img', attrs);
+        expect(vnode.attrs).to.deep.equal(attrs);
       });
 
     });
@@ -288,8 +343,22 @@ describe('@phosphor/virtualdom', () => {
 
   });
 
-  describe('VirtualDOM', () => {
+  describe('hpass()', () => {
 
+    it('should create a new virtual element passthru node', () => {
+      let vnode = hpass(
+        {
+          render: (host: HTMLElement) => {},
+          unrender: (host: HTMLElement) =>{}
+        },
+        'div'
+      );
+      expect(vnode).to.be.an.instanceof(VirtualElementPass);
+    });
+
+  });
+
+  describe('VirtualDOM', () => {
     describe('realize()', () => {
 
       it('should create a real DOM node from a virtual DOM node', () => {
@@ -417,6 +486,48 @@ describe('@phosphor/virtualdom', () => {
         expect(div.textContent).to.equal('bar');
       });
 
+    });
+
+  });
+
+  describe('VirtualDOM passthru', () => {
+    const rendererClosure = (record = {child: undefined, cleanedUp: false}) => {
+      return {
+        render: (host: HTMLElement) => {
+          const renderNode = document.createElement('div');
+          renderNode.className = 'p-render';
+          host.appendChild(renderNode);
+          (record.child as any) = renderNode;
+        },
+        unrender: (host: HTMLElement) => {
+          host.removeChild(host.lastChild as HTMLElement);
+          record.cleanedUp = true;
+        }
+      }
+    };
+
+    describe('render()', () => {
+      describe('should render child node', () => {
+        let host = document.createElement('div');
+        let record: any = {};
+        let children = [h.a(), h.span(), h.div(hpass(rendererClosure(record), 'span'))];
+        VirtualDOM.render(children, host);
+        expect(host.children[2].children[0]).to.equal(record.child);
+        expect(host.children[2].children[0].className).to.equal('p-render');
+      });
+
+      describe('should cleanup child node', () => {
+        let host = document.createElement('div');
+        let record: any = {};
+        let children = [h.a(), h.span(), h.div(hpass(rendererClosure(record), 'span'))];
+        // first pass, render the hpass children
+        VirtualDOM.render(children, host);
+
+        children[2] = h.label();
+        // second pass, explicitly unrender the hpass children
+        VirtualDOM.render(children, host);
+        expect(record.cleanedUp).to.equal(true);
+      });
     });
 
   });

--- a/packages/virtualdom/tests/src/index.spec.ts
+++ b/packages/virtualdom/tests/src/index.spec.ts
@@ -491,13 +491,13 @@ describe('@phosphor/virtualdom', () => {
   });
 
   describe('VirtualDOM passthru', () => {
-    const rendererClosure = (record = {child: undefined, cleanedUp: false}) => {
+    const rendererClosure = (record: any = {}) => {
       return {
         render: (host: HTMLElement) => {
           const renderNode = document.createElement('div');
           renderNode.className = 'p-render';
           host.appendChild(renderNode);
-          (record.child as any) = renderNode;
+          record.child = renderNode;
         },
         unrender: (host: HTMLElement) => {
           host.removeChild(host.lastChild as HTMLElement);
@@ -506,10 +506,30 @@ describe('@phosphor/virtualdom', () => {
       }
     };
 
+    describe('realize()', () => {
+      it('should realize successfully', () => {
+        let node = VirtualDOM.realize(hpass(rendererClosure(), 'span'));
+        expect(node.tagName.toLowerCase()).to.equal('span');
+        expect(node.children[0].tagName.toLowerCase()).to.equal('div');
+        expect(node.children[0].className).to.equal('p-render');
+      });
+
+    });
+
     describe('render()', () => {
+      it('should render successfully at top of tree', () => {
+        let host = document.createElement('div');
+
+        VirtualDOM.render(hpass(rendererClosure(), 'span'), host);
+        expect(host.children[0].tagName.toLowerCase()).to.equal('span');
+        expect(host.children[0].children[0].tagName.toLowerCase()).to.equal('div');
+        expect(host.children[0].children[0].className).to.equal('p-render');
+      });
+
       it('should render child node', () => {
         let host = document.createElement('div');
-        let record: any = {};
+        let record: any = {child: undefined, cleanedUp: false};
+
         let children = [h.a(), h.span(), h.div(h.div(), hpass(rendererClosure(record), 'span'), h.div())];
         VirtualDOM.render(children, host);
         expect(host.children[2].children[1].children[0]).to.equal(record.child);
@@ -518,7 +538,7 @@ describe('@phosphor/virtualdom', () => {
 
       it('should cleanup child node', () => {
         let host = document.createElement('div');
-        let record: any = {};
+        let record: any = {child: undefined, cleanedUp: false};
 
         // first pass, render the hpass children
         let children0 = [h.a(), h.span(), h.div(h.div(), hpass(rendererClosure(record), 'span'), h.div())];

--- a/packages/virtualdom/tests/tsconfig.json
+++ b/packages/virtualdom/tests/tsconfig.json
@@ -9,6 +9,7 @@
     "moduleResolution": "node",
     "target": "ES5",
     "outDir": "build",
+    "sourceMap": true,
     "lib": [
       "ES5",
       "DOM"

--- a/packages/virtualdom/tests/webpack.config.js
+++ b/packages/virtualdom/tests/webpack.config.js
@@ -4,5 +4,6 @@ module.exports = {
   entry: './build/index.spec.js',
   output: {
     filename: './build/bundle.test.js'
-  }
+  },
+  devtool: 'inline-source-map'
 }

--- a/packages/virtualdom/tests/webpack.config.js
+++ b/packages/virtualdom/tests/webpack.config.js
@@ -6,4 +6,4 @@ module.exports = {
     filename: './build/bundle.test.js'
   },
   devtool: 'inline-source-map'
-}
+};

--- a/packages/virtualdom/tsconfig.json
+++ b/packages/virtualdom/tsconfig.json
@@ -15,6 +15,7 @@
       "ES2015.Collection",
       "DOM"
     ],
+    "sourceMap": true,
     "types": [],
     "rootDir": "src"
   },

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -36,8 +36,13 @@
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
     "test": "npm run test:firefox",
+    "test:debug": "npm run test:debug:firefox",
     "test:chrome": "cd tests && karma start --browsers=Chrome",
+    "test:chrome-headless": "cd tests && karma start --browsers=ChromeHeadless",
     "test:firefox": "cd tests && karma start --browsers=Firefox",
+    "test:debug:chrome": "cd tests && karma start --browsers=Chrome --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
+    "test:debug:chrome-headless": "cd tests && karma start  --browsers=ChromeHeadless --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
+    "test:debug:firefox": "cd tests && karma start --browsers=Firefox --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
     "test:ie": "cd tests && karma start --browsers=IE",
     "watch": "tsc --build --watch"
   },

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -1341,8 +1341,8 @@ namespace TabBar {
       const { title } = data;
       let className = this.createIconClass(data);
 
-      if (title.iconPass) {
-        return hpass(title.iconPass);
+      if (title.iconRender) {
+        return hpass(title.iconRender, 'div');
       } else {
         return h.div({className}, data.title.iconLabel);
       }

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -30,7 +30,7 @@ import {
 } from '@phosphor/signaling';
 
 import {
-  ElementDataset, ElementInlineStyle, VirtualDOM, VirtualElement, h, hpass, VirtualNode
+  ElementDataset, ElementInlineStyle, VirtualDOM, VirtualElement, VirtualElementPass, h, hpass
 } from '@phosphor/virtualdom';
 
 import {
@@ -1337,7 +1337,7 @@ namespace TabBar {
      *
      * @returns A virtual element representing the tab icon.
      */
-    renderIcon(data: IRenderData<any>): VirtualNode {
+    renderIcon(data: IRenderData<any>): VirtualElement | VirtualElementPass {
       const { title } = data;
       let className = this.createIconClass(data);
 

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -1341,8 +1341,8 @@ namespace TabBar {
       const { title } = data;
       let className = this.createIconClass(data);
 
-      if (title.iconRender) {
-        return hpass(title.iconRender, 'div');
+      if (title.iconRenderer) {
+        return hpass(title.iconRenderer, 'div');
       } else {
         return h.div({className}, data.title.iconLabel);
       }

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -30,7 +30,7 @@ import {
 } from '@phosphor/signaling';
 
 import {
-  ElementDataset, ElementInlineStyle, VirtualDOM, VirtualElement, h
+  ElementDataset, ElementInlineStyle, VirtualDOM, VirtualElement, h, hpass, VirtualNode
 } from '@phosphor/virtualdom';
 
 import {
@@ -1337,9 +1337,15 @@ namespace TabBar {
      *
      * @returns A virtual element representing the tab icon.
      */
-    renderIcon(data: IRenderData<any>): VirtualElement {
+    renderIcon(data: IRenderData<any>): VirtualNode {
+      const { title } = data;
       let className = this.createIconClass(data);
-      return h.div({ className }, data.title.iconLabel);
+
+      if (title.iconPass) {
+        return hpass(title.iconPass);
+      } else {
+        return h.div({className}, data.title.iconLabel);
+      }
     }
 
     /**

--- a/packages/widgets/src/title.ts
+++ b/packages/widgets/src/title.ts
@@ -44,8 +44,8 @@ class Title<T> {
     if (options.iconLabel !== undefined) {
       this._iconLabel = options.iconLabel;
     }
-    if (options.iconRender !== undefined) {
-      this._iconRender = options.iconRender;
+    if (options.iconRenderer !== undefined) {
+      this._iconRenderer = options.iconRenderer;
     }
     if (options.caption !== undefined) {
       this._caption = options.caption;
@@ -175,15 +175,15 @@ class Title<T> {
     this._changed.emit(undefined);
   }
 
-  get iconRender(): VirtualElementPass.IRender {
-    return this._iconRender;
+  get iconRenderer(): VirtualElementPass.IRenderer {
+    return this._iconRenderer;
   }
 
-  set iconRender(value: VirtualElementPass.IRender) {
-    if (this._iconRender === value) {
+  set iconRenderer(value: VirtualElementPass.IRenderer) {
+    if (this._iconRenderer === value) {
       return;
     }
-    this._iconRender = value;
+    this._iconRenderer = value;
     this._changed.emit(undefined);
   }
 
@@ -285,7 +285,7 @@ class Title<T> {
   private _mnemonic = -1;
   private _iconClass = '';
   private _iconLabel = '';
-  private _iconRender: VirtualElementPass.IRender;
+  private _iconRenderer: VirtualElementPass.IRenderer;
   private _className = '';
   private _closable = false;
   private _dataset: Title.Dataset;
@@ -339,7 +339,7 @@ namespace Title {
      */
     iconLabel?: string;
 
-    iconRender?: VirtualElementPass.IRender;
+    iconRenderer?: VirtualElementPass.IRenderer;
 
     /**
      * The caption for the title.

--- a/packages/widgets/src/title.ts
+++ b/packages/widgets/src/title.ts
@@ -44,8 +44,8 @@ class Title<T> {
     if (options.iconLabel !== undefined) {
       this._iconLabel = options.iconLabel;
     }
-    if (options.iconPass !== undefined) {
-      this._iconPass = options.iconPass;
+    if (options.iconRender !== undefined) {
+      this._iconRender = options.iconRender;
     }
     if (options.caption !== undefined) {
       this._caption = options.caption;
@@ -175,15 +175,15 @@ class Title<T> {
     this._changed.emit(undefined);
   }
 
-  get iconPass(): VirtualElementPass.IProps {
-    return this._iconPass;
+  get iconRender(): VirtualElementPass.IRender {
+    return this._iconRender;
   }
 
-  set iconPass(value: VirtualElementPass.IProps) {
-    if (this._iconPass === value) {
+  set iconRender(value: VirtualElementPass.IRender) {
+    if (this._iconRender === value) {
       return;
     }
-    this._iconPass = value;
+    this._iconRender = value;
     this._changed.emit(undefined);
   }
 
@@ -285,7 +285,7 @@ class Title<T> {
   private _mnemonic = -1;
   private _iconClass = '';
   private _iconLabel = '';
-  private _iconPass: VirtualElementPass.IProps;
+  private _iconRender: VirtualElementPass.IRender;
   private _className = '';
   private _closable = false;
   private _dataset: Title.Dataset;
@@ -339,7 +339,7 @@ namespace Title {
      */
     iconLabel?: string;
 
-    iconPass?: VirtualElementPass.IProps;
+    iconRender?: VirtualElementPass.IRender;
 
     /**
      * The caption for the title.

--- a/packages/widgets/src/title.ts
+++ b/packages/widgets/src/title.ts
@@ -9,6 +9,8 @@ import {
   ISignal, Signal
 } from '@phosphor/signaling';
 
+import { VirtualElementPass } from "@phosphor/virtualdom";
+
 
 /**
  * An object which holds data related to an object's title.
@@ -41,6 +43,9 @@ class Title<T> {
     }
     if (options.iconLabel !== undefined) {
       this._iconLabel = options.iconLabel;
+    }
+    if (options.iconPass !== undefined) {
+      this._iconPass = options.iconPass;
     }
     if (options.caption !== undefined) {
       this._caption = options.caption;
@@ -170,6 +175,18 @@ class Title<T> {
     this._changed.emit(undefined);
   }
 
+  get iconPass(): VirtualElementPass.IProps {
+    return this._iconPass;
+  }
+
+  set iconPass(value: VirtualElementPass.IProps) {
+    if (this._iconPass === value) {
+      return;
+    }
+    this._iconPass = value;
+    this._changed.emit(undefined);
+  }
+
   /**
    * Get the caption for the title.
    *
@@ -268,6 +285,7 @@ class Title<T> {
   private _mnemonic = -1;
   private _iconClass = '';
   private _iconLabel = '';
+  private _iconPass: VirtualElementPass.IProps;
   private _className = '';
   private _closable = false;
   private _dataset: Title.Dataset;
@@ -320,6 +338,8 @@ namespace Title {
      * The icon label for the title.
      */
     iconLabel?: string;
+
+    iconPass?: VirtualElementPass.IProps;
 
     /**
      * The caption for the title.

--- a/packages/widgets/src/title.ts
+++ b/packages/widgets/src/title.ts
@@ -175,10 +175,22 @@ class Title<T> {
     this._changed.emit(undefined);
   }
 
+  /**
+   * Get the icon renderer for the title.
+   *
+   * #### Notes
+   * The default value is undefined.
+   */
   get iconRenderer(): VirtualElementPass.IRenderer {
     return this._iconRenderer;
   }
 
+  /**
+   * Set the icon renderer for the title.
+   *
+   * #### Notes
+   * A renderer is an object that supplies a render and unrender function.
+   */
   set iconRenderer(value: VirtualElementPass.IRenderer) {
     if (this._iconRenderer === value) {
       return;
@@ -339,6 +351,10 @@ namespace Title {
      */
     iconLabel?: string;
 
+    /**
+     * An object that supplies render and unrender functions used
+     * to create and cleanup the icon of the title.
+     */
     iconRenderer?: VirtualElementPass.IRenderer;
 
     /**

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -30,7 +30,7 @@ import {
 } from '@phosphor/messaging';
 
 import {
-  VirtualDOM
+  VirtualDOM, VirtualElement
 } from '@phosphor/virtualdom';
 
 import {
@@ -871,7 +871,7 @@ describe('@phosphor/widgets', () => {
           data.title.mnemonic = 1;
           let label = renderer.formatLabel(data);
           expect((label as any)[0]).to.equal('f');
-          let node = VirtualDOM.realize((label as any)[1]);
+          let node = VirtualDOM.realize(((label as any)[1]) as VirtualElement);
           expect(node.className).to.contain('p-MenuBar-itemMnemonic');
           expect(node.textContent).to.equal('o');
           expect((label as any)[2]).to.equal('o');

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -26,7 +26,7 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  VirtualDOM
+  VirtualDOM, VirtualElement
 } from '@phosphor/virtualdom';
 
 
@@ -1308,7 +1308,7 @@ describe('@phosphor/widgets', () => {
         it('should render the icon element for a tab', () => {
           let renderer = new TabBar.Renderer();
           let vNode = renderer.renderIcon({ title, current: true, zIndex: 1 });
-          let node = VirtualDOM.realize(vNode);
+          let node = VirtualDOM.realize(vNode as VirtualElement);
           expect(node.className).to.contain('p-TabBar-tabIcon');
           expect(node.classList.contains(title.icon)).to.equal(true);
         });


### PR DESCRIPTION
Fixes #395, #436, and probably a bunch of other issues.

This PR adds the `hpass` function and `VirtualElementPass` class described in #436. There are still a number of unanswered questions as to the detials of their implementations. For example, should `VirtualElementPass` allow for children and, if so, how should they be handled?